### PR TITLE
The word Dynamic is misspelled.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_hacker.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_hacker.py
@@ -32,7 +32,7 @@ from tensorflow.python.training import optimizer
 
 
 class _DenseDynamicEmbeddingTrainableProcessor(optimizer._OptimizableVariable):
-    """Processor for dense DynamiceEmbedding."""
+    """Processor for dense DynamicEmbedding."""
 
     def __init__(self, v):
         self._v = v


### PR DESCRIPTION
Misspelled word:
  -  """Processor for dense DynamiceEmbedding."""
  + """Processor for dense DynamicEmbedding."""