### PR TITLE
[if trainable_ not in params.trainable_wrappers]:The truth value of a…

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -491,8 +491,11 @@ def embedding_lookup(
       embeddings = array_ops.identity(trainable_)
       embeddings.set_shape(trainable_shape)
 
-    if trainable_ not in params.trainable_wrappers:
-      params.trainable_wrappers.append(trainable_)
+    for existed in params.trainable_wrappers:
+      if trainable_.name == existed.name:
+        break
+      else:
+        params.trainable_wrappers.append(trainable_)
 
   return (embeddings, trainable_) if return_trainable else embeddings
 


### PR DESCRIPTION
**Problem Description**
File "/usr/local/lib/python3.6/dist-packages/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py", line 499, in embedding_lookup
    if trainable_ not in params.trainable_wrappers:
  File "/usr/local/lib/python3.6/dist-packages/tensorflow/python/framework/ops.py", line 992, in __bool__
    return bool(self._numpy())
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all().  

**Code modification**
1. Traverse params.trainable_wrappers;
2. Judge whether trainable_ exists, if not, add it, otherwise pass.

**Test code**
```
import tensorflow as tf
from tensorflow.keras.layers import Dense, Lambda
import tensorflow_recommenders_addons.dynamic_embedding as de
import numpy as np

idx = np.random.randint(0, 10, 100)
label = np.array([1.0 if a % 2 == 0 else 0.0 for a in idx], dtype=np.float32)

class MyModel(tf.keras.Model):
    def __init__(self):
        super(MyModel, self).__init__()
        self.w = de.get_variable(name="dynamic_embeddings", dim=8, initializer=np.random.random(8))
        self.d0 = Lambda(lambda x: de.embedding_lookup(params=self.w, ids=x, name="wide-sparse-weights"))
        self.d1 = Dense(10, activation='relu')
        self.d2 = Dense(1, activation='sigmoid')
        self.x0 = None

    def call(self, x):
        self.x0 = self.d0(x)
        x1 = self.d1(self.x0)
        return self.d2(x1)

model = MyModel()
loss_func = tf.keras.losses.BinaryCrossentropy()
optimizer = tf.keras.optimizers.Adagrad(learning_rate=.5)
train_loss = tf.keras.metrics.Mean(name='train_loss')

def train_step(x, label, print_loss=False):
    with tf.GradientTape() as tape:
        logits = model(x)
        loss = loss_func(logits, label)
    trainable_weights = model.trainable_variables
    grads = tape.gradient(loss, trainable_weights)
    optimizer.apply_gradients(zip(grads, trainable_weights))
    if print_loss:
        print("loss:{}".format(train_loss(loss).numpy()))

def emb_sum():
    a = de.embedding_lookup(params=model.w, ids=np.array([2, 3]), name="wide-sparse-weights")
    return a.numpy().sum()

def kernel_sum():
    return model.d1.kernel.numpy().sum()

print("emb sum:{}".format(emb_sum()))
for i in range(20):
    train_step(idx.reshape(100, 1), label.reshape(100, 1))
print("emb sum:{}".format(emb_sum()))
print("kernel sum:{}".format(kernel_sum()))
# train more
for i in range(10):
    train_step(idx.reshape(100, 1), label.reshape(100, 1), print_loss=True)
print("emb sum:{}".format(emb_sum()))
print("kernel sum:{}".format(kernel_sum()))

# print trainable weights
print([v.name for v in model.trainable_weights])
```
**Test run results**
.........
emb sum:6.234718322753906
kernel sum:-0.2206200659275055
loss:7.599799156188965
loss:7.598476409912109
loss:7.597177505493164
loss:7.595917701721191
loss:7.5946946144104
loss:7.593507289886475
loss:7.592360973358154
loss:7.5912556648254395
loss:7.590188026428223
loss:7.5891618728637695
emb sum:6.234718322753906
kernel sum:0.6952447295188904
['my_model/dense/kernel:0', 'my_model/dense/bias:0', 'my_model/dense_1/kernel:0', 'my_model/dense_1/bias:0']

@rhdong 
Please help me review, thank you.
