### PR TITLE
Support custom init_size_ parameter for cuckoohash_map.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/cuckoo_hashtable_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/cuckoo_hashtable_ops.cc
@@ -231,6 +231,7 @@ REGISTER_OP("TFRA>CuckooHashTableOfTensors")
     .Attr("key_dtype: type")
     .Attr("value_dtype: type")
     .Attr("value_shape: shape = {}")
+    .Attr("init_size: int = 0")
     .SetIsStateful()
     .SetShapeFn([](InferenceContext* c) {
       PartialTensorShape value_p;

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/BUILD
@@ -39,3 +39,13 @@ py_test(
         "//tensorflow_recommenders_addons",
     ],
 )
+
+py_test(
+    name = "cuckoo_hashtable_ops_test",
+    srcs = ["cuckoo_hashtable_ops_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_recommenders_addons",
+    ],
+)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/cuckoo_hashtable_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/cuckoo_hashtable_ops_test.py
@@ -1,0 +1,60 @@
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""unit tests of cuckoo hashtable ops
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import sys
+
+from tensorflow_recommenders_addons import dynamic_embedding as de
+
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
+from tensorflow.python.platform import test
+
+default_config = config_pb2.ConfigProto(
+    allow_soft_placement=False,
+    gpu_options=config_pb2.GPUOptions(allow_growth=True))
+
+
+class CuckooHashtableTest(test.TestCase):
+
+  @test_util.run_in_graph_and_eager_modes()
+  def test_dynamic_embedding_variable_set_init_size(self):
+    test_list = [["CPU", False, 12345, 12345], ["CPU", False, 0, 8192]]
+    if test_util.is_gpu_available():
+      test_list = [["GPU", True, 54321, 54321], ["GPU", True, 0, 8192]]
+    id = 0
+    for dev_str, use_gpu, init_size, expect_size in test_list:
+      with self.session(use_gpu=use_gpu, config=default_config):
+        with self.captureWritesToStream(sys.stderr) as printed:
+          table = de.get_variable("2021-" + str(id),
+                                  dtypes.int64,
+                                  dtypes.int32,
+                                  initializer=0,
+                                  dim=8,
+                                  init_size=init_size)
+          self.evaluate(table.size())
+        id += 1
+        self.assertTrue("I" in printed.contents())
+        self.assertTrue(dev_str in printed.contents())
+        self.assertTrue("size = {}".format(expect_size) in printed.contents())
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
@@ -56,6 +56,7 @@ class CuckooHashTable(LookupInterface):
       default_value,
       name="CuckooHashTable",
       checkpoint=True,
+      init_size=0,
   ):
     """Creates an empty `CuckooHashTable` object.
 
@@ -70,6 +71,8 @@ class CuckooHashTable(LookupInterface):
           checkpoint: if True, the contents of the table are saved to and restored
             from checkpoints. If `shared_name` is empty for a checkpointed table, it
             is shared using the table node name.
+          init_size: initial size for the Variable and initial size of each hash 
+            tables will be int(init_size / N), N is the number of the devices.
 
         Returns:
           A `CuckooHashTable` object.
@@ -83,6 +86,7 @@ class CuckooHashTable(LookupInterface):
     self._checkpoint = checkpoint
     self._key_dtype = key_dtype
     self._value_dtype = value_dtype
+    self.init_size = init_size
     self._name = name
 
     self._shared_name = None
@@ -122,6 +126,7 @@ class CuckooHashTable(LookupInterface):
         key_dtype=self._key_dtype,
         value_dtype=self._value_dtype,
         value_shape=self._default_value.get_shape(),
+        init_size=self.init_size,
         name=self._name,
     )
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -118,6 +118,7 @@ class Variable(trackable.TrackableResource):
       initializer=None,
       trainable=True,
       checkpoint=True,
+      init_size=0,
   ):
     """Creates an empty `Variable` object.
 
@@ -154,6 +155,8 @@ class Variable(trackable.TrackableResource):
             saved to and restored from checkpoints.
             If `shared_name` is empty for a checkpointed table,
             it is shared using the table node name.
+          init_size: initial size for the Variable and initial size of each hash 
+            tables will be int(init_size / N), N is the number of the devices.
 
         Returns:
           A `Variable` object.
@@ -188,6 +191,7 @@ class Variable(trackable.TrackableResource):
     self._tables = []
     self.size_ops = []
     self.shard_num = len(self.devices)
+    self.init_size = int(init_size / self.shard_num)
 
     key_dtype_list = [dtypes.int32, dtypes.int64]
     value_dtype_list = [
@@ -225,6 +229,7 @@ class Variable(trackable.TrackableResource):
                 default_value=static_default_value,
                 name=self._make_name(idx),
                 checkpoint=self.checkpoint,
+                init_size=self.init_size,
             )
 
             self._tables.append(mht)
@@ -433,6 +438,7 @@ def get_variable(
     initializer=None,
     trainable=True,
     checkpoint=True,
+    init_size=0,
 ):
   """Gets an `Variable` object with this name if it exists,
          or create a new one.
@@ -490,6 +496,7 @@ def get_variable(
         initializer=initializer,
         trainable=trainable,
         checkpoint=checkpoint,
+        init_size=init_size,
     )
     scope_store._vars[full_name] = var_
   return scope_store._vars[full_name]

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -20,7 +20,7 @@ RUN python configure.py
 RUN pip install -e ./
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/install_so_files.sh
-RUN pytest -v -n auto --durations=25 --doctest-modules ./tensorflow_recommenders_addons \
+RUN pytest -v -s -n auto --durations=25 --doctest-modules ./tensorflow_recommenders_addons \
     --cov=tensorflow_recommenders_addons ./tensorflow_recommenders_addons/
 
 RUN bazel build --enable_runfiles build_pip_pkg

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -32,7 +32,7 @@ RUN python configure.py
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/install_so_files.sh
 
-RUN pytest -v /recommenders-addons/tools/testing/
+RUN pytest -v -s /recommenders-addons/tools/testing/
 RUN touch /ok.txt
 
 # -------------------------------
@@ -127,7 +127,7 @@ RUN python configure.py
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/install_so_files.sh
 RUN pip install --no-deps -e .
-RUN pytest -v -n auto ./tensorflow_recommenders_addons/dynamic_embedding
+RUN pytest -v -s -n auto ./tensorflow_recommenders_addons/dynamic_embedding
 RUN touch /ok.txt
 
 # -------------------------------

--- a/tools/testing/build_and_run_tests.sh
+++ b/tools/testing/build_and_run_tests.sh
@@ -35,4 +35,4 @@ if ! [ -x "$(command -v nvidia-smi)" ]; then
 fi
 
 
-python -m pytest -v --functions-durations=20 --modules-durations=5 $EXTRA_ARGS ./tensorflow_recommenders_addons
+python -m pytest -v -s --functions-durations=20 --modules-durations=5 $EXTRA_ARGS ./tensorflow_recommenders_addons


### PR DESCRIPTION
**Set the init_size_ parameter mode**
1. Set environment variable
```
export TF_HASHTABLE_INIT_SIZE=100000000
```
2. Set get_variable parameter
```
import tensorflow as tf
import tensorflow_recommenders_addons.dynamic_embedding as de

# sparse weights defination:
w = de.get_variable(name="dynamic_embeddings",
                    devices=["/job:ps/replica:0/task:0/CPU:0",],
                    initializer=tf.random_normal_initializer(0, 0.005),
                    dim=8,
                    init_size=100000000)
```
3. Default
```
1024 * 8,  // 8192 KV pairs by default
```
