### PR TITLE
Support restricted variable

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
@@ -40,6 +40,11 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embeddi
     get_variable,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
     Variable,)
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.restrict_policies import (
+    RestrictPolicy,
+    TimestampRestrictPolicy,
+    FrequencyRestrictPolicy,
+)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
     GraphKeys,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_patch import (

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/BUILD
@@ -41,6 +41,16 @@ py_test(
 )
 
 py_test(
+    name = "restrict_policies_test",
+    srcs = ["restrict_policies_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_recommenders_addons",
+    ],
+)
+
+py_test(
     name = "cuckoo_hashtable_ops_test",
     srcs = ["cuckoo_hashtable_ops_test.py"],
     python_version = "PY3",

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/restrict_policies_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/restrict_policies_test.py
@@ -1,0 +1,584 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Unit tests of restrict policies"""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import os
+import tempfile
+import time
+
+from tensorflow_recommenders_addons import dynamic_embedding as de
+
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.client import session
+from tensorflow.python.eager import context
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
+from tensorflow.python.keras import optimizer_v2
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
+from tensorflow.python.platform import test
+from tensorflow.python.training import adadelta
+from tensorflow.python.training import adagrad
+from tensorflow.python.training import adagrad_da
+from tensorflow.python.training import adam
+from tensorflow.python.training import ftrl
+from tensorflow.python.training import gradient_descent
+from tensorflow.python.training import momentum
+from tensorflow.python.training import proximal_adagrad
+from tensorflow.python.training import proximal_gradient_descent as pgd
+from tensorflow.python.training import rmsprop
+from tensorflow.python.training import server_lib
+from tensorflow.python.training import training_util
+
+
+def _simple_loss(embedding):
+  x = constant_op.constant(np.random.rand(2, 3), dtype=dtypes.float32)
+  pred = math_ops.matmul(embedding, x)
+  loss = pred * pred
+  return loss
+
+
+default_config = config_pb2.ConfigProto(
+    allow_soft_placement=False,
+    gpu_options=config_pb2.GPUOptions(allow_growth=True))
+
+
+class RestrictPolicyV1TestBase(object):
+
+  def commonly_apply_update_verify(self):
+    raise NotImplementedError
+
+  def commonly_apply_restriction_verify(self, optimizer):
+    raise NotImplementedError
+
+  # apply update test
+  @test_util.deprecated_graph_mode_only
+  def test_apply_update(self):
+    self.commonly_apply_update_verify()
+
+  # apply restrict test
+  @test_util.deprecated_graph_mode_only
+  def test_adadelta_apply_restriction(self):
+    opt = adadelta.AdadeltaOptimizer()
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adagrad_apply_restriction(self):
+    opt = adagrad.AdagradOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adagrad_da_apply_restriction(self):
+    gstep = training_util.create_global_step()
+    opt = adagrad_da.AdagradDAOptimizer(0.1, gstep)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adam_apply_restriction(self):
+    opt = adam.AdamOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_ftrl_apply_restriction(self):
+    opt = ftrl.FtrlOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_gradient_descent_apply_restriction(self):
+    opt = gradient_descent.GradientDescentOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_momentum_apply_restriction(self):
+    opt = momentum.MomentumOptimizer(0.1, 0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_proximal_adagrad_apply_restriction(self):
+    opt = proximal_adagrad.ProximalAdagradOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_pgd_apply_restriction(self):
+    opt = pgd.ProximalGradientDescentOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+  @test_util.deprecated_graph_mode_only
+  def test_rmsprop_apply_restriction(self):
+    opt = rmsprop.RMSPropOptimizer(0.1)
+    self.commonly_apply_restriction_verify(opt)
+
+
+class TimestampRestrictPolicyV1Test(test.TestCase, RestrictPolicyV1TestBase):
+
+  def commonly_apply_update_verify(self):
+    first_inputs = np.array(range(3), dtype=np.int64)
+    second_inputs = np.array(range(1, 4), dtype=np.int64)
+    overdue_features = np.array([0], dtype=np.int64)
+    updated_features = np.array(range(1, 4), dtype=np.int64)
+    with session.Session(config=default_config) as sess:
+      ids = array_ops.placeholder(dtypes.int64)
+      var = de.get_variable('sp_var',
+                            key_dtype=ids.dtype,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            init_size=256,
+                            dim=2)
+      embed_w, trainable = de.embedding_lookup(var, ids, return_trainable=True)
+      policy = de.TimestampRestrictPolicy(var)
+      update_op = policy.apply_update(ids)
+
+      self.assertAllEqual(sess.run(policy.status.size()), 0)
+      sess.run(update_op, feed_dict={ids: first_inputs})
+      self.assertAllEqual(sess.run(policy.status.size()), 3)
+      time.sleep(1)
+      sess.run(update_op, feed_dict={ids: second_inputs})
+      self.assertAllEqual(sess.run(policy.status.size()), 4)
+
+      keys, tstp = sess.run(policy.status.export())
+      kvs = sorted(dict(zip(keys, tstp)).items())
+      tstp = np.array([x[1] for x in kvs])
+      for x in tstp[overdue_features]:
+        for y in tstp[updated_features]:
+          self.assertLess(x, y)
+
+  def commonly_apply_restriction_verify(self, optimizer):
+    first_inputs = np.array(range(6), dtype=np.int64)
+    second_inputs = np.array(range(4, 9), dtype=np.int64)
+    overdue_features = np.array(range(4), dtype=np.int64)
+    updated_features = np.array(range(4, 9), dtype=np.int64)
+    all_input_features = np.array(range(9), dtype=np.int64)
+    embedding_dim = 2
+    oversize_trigger = 100
+    optimizer = de.DynamicEmbeddingOptimizer(optimizer)
+
+    with session.Session(config=default_config) as sess:
+      ids = array_ops.placeholder(dtypes.int64)
+      var = de.get_variable('sp_var',
+                            key_dtype=ids.dtype,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=embedding_dim,
+                            restrict_policy=de.TimestampRestrictPolicy)
+      embed_w, trainable = de.embedding_lookup(var, ids, return_trainable=True)
+      loss = _simple_loss(embed_w)
+      train_op = optimizer.minimize(loss, var_list=[trainable])
+
+      slot_params = [
+          optimizer.get_slot(trainable, name).params
+          for name in optimizer.get_slot_names()
+      ]
+      all_vars = [var] + slot_params + [var.restrict_policy.status]
+
+      sess.run(variables.global_variables_initializer())
+
+      sess.run([train_op], feed_dict={ids: first_inputs})
+      time.sleep(1)
+      sess.run([train_op], feed_dict={ids: second_inputs})
+      for v in all_vars:
+        self.assertAllEqual(sess.run(v.size()), 9)
+      keys, tstp = sess.run(var.restrict_policy.status.export())
+      kvs = sorted(dict(zip(keys, tstp)).items())
+      tstp = np.array([x[1] for x in kvs])
+      for x in tstp[overdue_features]:
+        for y in tstp[updated_features]:
+          self.assertLess(x, y)
+
+      sess.run(
+          var.restrict_policy.apply_restriction(len(updated_features),
+                                                trigger=oversize_trigger))
+      for v in all_vars:
+        self.assertAllEqual(sess.run(v.size()), len(all_input_features))
+
+      sess.run(
+          var.restrict_policy.apply_restriction(len(updated_features),
+                                                trigger=len(updated_features)))
+      for v in all_vars:
+        self.assertAllEqual(sess.run(v.size()), len(updated_features))
+      keys, _ = sess.run(var.export())
+      self.assertAllEqual(keys, updated_features)
+
+
+class FrequencyRestrictPolicyV1Test(test.TestCase, RestrictPolicyV1TestBase):
+
+  def commonly_apply_update_verify(self):
+    first_inputs = np.array(range(3), dtype=np.int64)
+    second_inputs = np.array(range(1, 4), dtype=np.int64)
+    overdue_features = np.array([0, 3], dtype=np.int64)
+    updated_features = np.array(range(1, 3), dtype=np.int64)
+    with session.Session(config=default_config) as sess:
+      ids = array_ops.placeholder(dtypes.int64)
+      var = de.get_variable('sp_var',
+                            key_dtype=ids.dtype,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=2)
+      embed_w, trainable = de.embedding_lookup(var, ids, return_trainable=True)
+      policy = de.FrequencyRestrictPolicy(var)
+      update_op = policy.apply_update(ids)
+
+      self.assertAllEqual(sess.run(policy.status.size()), 0)
+      sess.run(update_op, feed_dict={ids: first_inputs})
+      self.assertAllEqual(sess.run(policy.status.size()), 3)
+      time.sleep(1)
+      sess.run(update_op, feed_dict={ids: second_inputs})
+      self.assertAllEqual(sess.run(policy.status.size()), 4)
+
+      keys, freq = sess.run(policy.status.export())
+      kvs = sorted(dict(zip(keys, freq)).items())
+      freq = np.array([x[1] for x in kvs])
+      for x in freq[overdue_features]:
+        for y in freq[updated_features]:
+          self.assertLess(x, y)
+
+  def commonly_apply_restriction_verify(self, optimizer):
+    first_inputs = np.array(range(6), dtype=np.int64)
+    second_inputs = np.array(range(4, 9), dtype=np.int64)
+    overdue_features = np.array([0, 1, 2, 3, 6, 7, 8], dtype=np.int64)
+    updated_features = np.array(range(4, 6), dtype=np.int64)
+    all_input_features = np.array(range(9), dtype=np.int64)
+    embedding_dim = 2
+    oversize_trigger = 100
+    optimizer = de.DynamicEmbeddingOptimizer(optimizer)
+
+    with session.Session(config=default_config) as sess:
+      ids = array_ops.placeholder(dtypes.int64)
+      var = de.get_variable('sp_var',
+                            key_dtype=ids.dtype,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=embedding_dim,
+                            restrict_policy=de.FrequencyRestrictPolicy)
+      embed_w, trainable = de.embedding_lookup(var, ids, return_trainable=True)
+      loss = _simple_loss(embed_w)
+      train_op = optimizer.minimize(loss, var_list=[trainable])
+
+      slot_params = [
+          optimizer.get_slot(trainable, name).params
+          for name in optimizer.get_slot_names()
+      ]
+      all_vars = [var] + slot_params + [var.restrict_policy.status]
+
+      sess.run(variables.global_variables_initializer())
+
+      sess.run([train_op], feed_dict={ids: first_inputs})
+      sess.run([train_op], feed_dict={ids: second_inputs})
+      for v in all_vars:
+        self.assertAllEqual(sess.run(v.size()), 9)
+      keys, freq = sess.run(var.restrict_policy.status.export())
+      kvs = sorted(dict(zip(keys, freq)).items())
+      freq = np.array([x[1] for x in kvs])
+      for x in freq[overdue_features]:
+        for y in freq[updated_features]:
+          self.assertLess(x, y)
+
+      sess.run(
+          var.restrict_policy.apply_restriction(len(updated_features),
+                                                trigger=oversize_trigger))
+      for v in all_vars:
+        self.assertAllEqual(sess.run(v.size()), len(all_input_features))
+
+      sess.run(
+          var.restrict_policy.apply_restriction(len(updated_features),
+                                                trigger=len(updated_features)))
+      for v in all_vars:
+        self.assertAllEqual(sess.run(v.size()), len(updated_features))
+      keys, _ = sess.run(var.export())
+      self.assertAllEqual(keys, updated_features)
+
+
+class RestrictPolicyV2TestBase(object):
+
+  def commonly_apply_update_verify_v2(self):
+    raise NotImplementedError
+
+  def commonly_apply_restriction_verify_v2(self, optimizer):
+    raise NotImplementedError
+
+  # track test
+  @test_util.run_in_graph_and_eager_modes
+  def test_apply_update_verify_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    self.commonly_apply_update_verify_v2()
+
+  # apply restrict test
+  @test_util.run_in_graph_and_eager_modes
+  def test_adadelta_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.adadelta.Adadelta(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_adagrad_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.adagrad.Adagrad(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_adam_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.adam.Adam(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_adamax_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.adamax.Adamax(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_ftrl_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.ftrl.Ftrl(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_sgd_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.gradient_descent.SGD(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_nadam_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.nadam.Nadam(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_rmsprop_apply_restriction_v2(self):
+    if test_util.is_gpu_available():
+      self.skipTest('Skip GPU test for no GPU kernel')
+    opt = optimizer_v2.rmsprop.RMSprop(1.0)
+    self.commonly_apply_restriction_verify_v2(opt)
+
+
+class TimestampRestrictPolicyV2Test(test.TestCase, RestrictPolicyV2TestBase):
+
+  def commonly_apply_update_verify_v2(self):
+    if not context.executing_eagerly():
+      self.skipTest('Skip graph mode test.')
+
+    first_inputs = np.array(range(6), dtype=np.int64)
+    second_inputs = np.array(range(3, 9), dtype=np.int64)
+    overdue_features = np.array(range(3), dtype=np.int64)
+    updated_features = np.array(range(3, 9), dtype=np.int64)
+    all_features = np.array(range(9), dtype=np.int64)
+
+    with self.session(config=default_config):
+      var = de.get_variable('sp_var',
+                            key_dtype=dtypes.int64,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=2)
+      embed_w, trainable = de.embedding_lookup(var,
+                                               first_inputs,
+                                               return_trainable=True)
+      policy = de.TimestampRestrictPolicy(var)
+
+      self.assertAllEqual(policy.status.size(), 0)
+      policy.apply_update(first_inputs)
+      self.assertAllEqual(policy.status.size(), len(first_inputs))
+      time.sleep(1)
+      policy.apply_update(second_inputs)
+      self.assertAllEqual(policy.status.size(), len(all_features))
+
+      keys, tstp = policy.status.export()
+      kvs = sorted(dict(zip(keys.numpy(), tstp.numpy())).items())
+      tstp = np.array([x[1] for x in kvs])
+      for x in tstp[overdue_features]:
+        for y in tstp[updated_features]:
+          self.assertLess(x, y)
+
+  def commonly_apply_restriction_verify_v2(self, optimizer):
+    if not context.executing_eagerly():
+      self.skipTest('Skip graph mode test.')
+
+    optimizer = de.DynamicEmbeddingOptimizer(optimizer)
+    first_inputs = np.array(range(6), dtype=np.int64)
+    second_inputs = np.array(range(3, 9), dtype=np.int64)
+    overdue_features = np.array(range(3), dtype=np.int64)
+    updated_features = np.array(range(3, 9), dtype=np.int64)
+    all_inputs = np.array(range(9), dtype=np.int64)
+    oversize_trigger = 100
+    trainables = []
+
+    with self.session(config=default_config):
+      var = de.get_variable('sp_var',
+                            key_dtype=dtypes.int64,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=2,
+                            restrict_policy=de.TimestampRestrictPolicy)
+
+      def loss_fn(var, features, trainables):
+        embed_w, trainable = de.embedding_lookup(var,
+                                                 features,
+                                                 return_trainable=True)
+        trainables.clear()
+        trainables.append(trainable)
+        return _simple_loss(embed_w)
+
+      def var_fn():
+        return trainables
+
+      optimizer.minimize(lambda: loss_fn(var, first_inputs, trainables), var_fn)
+      self.assertAllEqual(var.size(), len(first_inputs))
+      slot_params = [
+          optimizer.get_slot(trainables[0], name).params
+          for name in optimizer.get_slot_names()
+      ]
+      all_vars = [var] + slot_params + [var.restrict_policy.status]
+
+      time.sleep(1)
+      optimizer.minimize(lambda: loss_fn(var, second_inputs, trainables),
+                         var_fn)
+      for v in all_vars:
+        keys, _ = v.export()
+        self.assertAllEqual(sorted(keys), all_inputs)
+      keys, tstp = var.restrict_policy.status.export()
+      kvs = sorted(dict(zip(keys.numpy(), tstp.numpy())).items())
+      tstp = np.array([x[1] for x in kvs])
+      for x in tstp[overdue_features]:
+        for y in tstp[updated_features]:
+          self.assertLess(x, y)
+
+      var.restrict_policy.apply_restriction(len(updated_features),
+                                            trigger=oversize_trigger)
+      for v in all_vars:
+        self.assertAllEqual(v.size(), len(all_inputs))
+      var.restrict_policy.apply_restriction(len(updated_features),
+                                            trigger=len(updated_features))
+      for v in all_vars:
+        keys, _ = v.export()
+        self.assertAllEqual(sorted(keys), updated_features)
+
+
+class FrequencyRestrictPolicyV2Test(test.TestCase, RestrictPolicyV2TestBase):
+
+  def commonly_apply_update_verify_v2(self):
+    if not context.executing_eagerly():
+      self.skipTest('Skip graph mode test.')
+
+    first_inputs = np.array(range(6), dtype=np.int64)
+    second_inputs = np.array(range(3, 9), dtype=np.int64)
+    overdue_features = np.array([0, 1, 2, 6, 7, 8], dtype=np.int64)
+    updated_features = np.array(range(3, 6), dtype=np.int64)
+    all_features = np.array(range(9), dtype=np.int64)
+
+    with self.session(config=default_config):
+      var = de.get_variable('sp_var',
+                            key_dtype=dtypes.int64,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=2)
+      embed_w, trainable = de.embedding_lookup(var,
+                                               first_inputs,
+                                               return_trainable=True)
+      policy = de.FrequencyRestrictPolicy(var)
+
+      self.assertAllEqual(policy.status.size(), 0)
+      policy.apply_update(first_inputs)
+      self.assertAllEqual(policy.status.size(), len(first_inputs))
+      time.sleep(1)
+      policy.apply_update(second_inputs)
+      self.assertAllEqual(policy.status.size(), len(all_features))
+
+      keys, freq = policy.status.export()
+      kvs = sorted(dict(zip(keys.numpy(), freq.numpy())).items())
+      freq = np.array([x[1] for x in kvs])
+      for x in freq[overdue_features]:
+        for y in freq[updated_features]:
+          self.assertLess(x, y)
+
+  def commonly_apply_restriction_verify_v2(self, optimizer):
+    if not context.executing_eagerly():
+      self.skipTest('Skip graph mode test.')
+
+    optimizer = de.DynamicEmbeddingOptimizer(optimizer)
+    first_inputs = np.array(range(6), dtype=np.int64)
+    second_inputs = np.array(range(3, 9), dtype=np.int64)
+    overdue_features = np.array([0, 1, 2, 6, 7, 8], dtype=np.int64)
+    updated_features = np.array(range(3, 6), dtype=np.int64)
+    all_inputs = np.array(range(9), dtype=np.int64)
+    oversize_trigger = 100
+    trainables = []
+
+    with self.session(config=default_config):
+      var = de.get_variable('sp_var',
+                            key_dtype=dtypes.int64,
+                            value_dtype=dtypes.float32,
+                            initializer=-0.1,
+                            dim=2,
+                            restrict_policy=de.FrequencyRestrictPolicy)
+
+      def loss_fn(var, features, trainables):
+        embed_w, trainable = de.embedding_lookup(var,
+                                                 features,
+                                                 return_trainable=True)
+        trainables.clear()
+        trainables.append(trainable)
+        return _simple_loss(embed_w)
+
+      def var_fn():
+        return trainables
+
+      optimizer.minimize(lambda: loss_fn(var, first_inputs, trainables), var_fn)
+      self.assertAllEqual(var.size(), len(first_inputs))
+      slot_params = [
+          optimizer.get_slot(trainables[0], name).params
+          for name in optimizer.get_slot_names()
+      ]
+      all_vars = [var] + slot_params + [var.restrict_policy.status]
+
+      optimizer.minimize(lambda: loss_fn(var, second_inputs, trainables),
+                         var_fn)
+      for v in all_vars:
+        keys, _ = v.export()
+        self.assertAllEqual(sorted(keys), all_inputs)
+      keys, freq = var.restrict_policy.status.export()
+      kvs = sorted(dict(zip(keys.numpy(), freq.numpy())).items())
+      freq = np.array([x[1] for x in kvs])
+      for x in freq[overdue_features]:
+        for y in freq[updated_features]:
+          self.assertLess(x, y)
+
+      var.restrict_policy.apply_restriction(len(updated_features),
+                                            trigger=oversize_trigger)
+      for v in all_vars:
+        self.assertAllEqual(v.size(), len(all_inputs))
+      var.restrict_policy.apply_restriction(len(updated_features),
+                                            trigger=len(updated_features))
+      for v in all_vars:
+        keys, _ = v.export()
+        self.assertAllEqual(sorted(keys), updated_features)
+
+
+if __name__ == '__main__':
+  test.main()

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The TensorFlow Recommenders-Addpnons Authors.
+# Copyright 2020 The TensorFlow Recommenders-Addons Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -74,6 +74,10 @@ def DynamicEmbeddingOptimizer(self):
       else:
         with ops.colocate_with(None, ignore_existing=True):
           _slots = [self.get_slot(var, _s) for _s in self.get_slot_names()]
+          # Add the optimizer slots to restricting list.
+          if var.params.restrict_policy is not None:
+            var.params.restrict_policy._track_optimizer_slots(_slots)
+
           with ops.control_dependencies([grad]):
             _before = [var.read_value()] + [_s.read_value() for _s in _slots]
           if isinstance(grad, ops.IndexedSlices):

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/restrict_policies.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/restrict_policies.py
@@ -1,0 +1,360 @@
+# Copyright 2021 The TensorFlow Recommenders-Addons Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# lint-as: python3
+"""Policies for restricting the dynamic embedding variable"""
+from tensorflow_recommenders_addons import dynamic_embedding as de
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import make_partition
+
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import gen_logging_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import nn_ops
+from tensorflow.python.ops import variable_scope
+from tensorflow.python.platform import tf_logging
+
+
+class RestrictPolicy(object):
+  """
+  Base class of restrict policies. Never use this class directly, but
+  instead of of its derived class.
+
+  This class defines the rules for tracking and restricting the size of the
+  `dynamic_embedding.Variable`. If the variable joins training via stateful
+  optimizer, the policy also manage the slots of the optimizer. It could own
+  a status to keep tracking the state of affairs of the features presented
+  in sparse `dynamic_embedding.Variable`.
+
+  `RestrictPolicy` requires a set of methods to be override, in its derived
+  policies: `apply_update`, `apply_restriction`, `status`.
+
+  * apply_update: keep tracking on the status of the sparse variable,
+      specifically the attributes of each key in sparse variable.
+  * apply_restriction: eliminate the features which are not legitimate.
+  """
+
+  def __init__(self, var):
+    """
+    Create a new RestrictPolicy.
+
+    Args:
+      var: A `dynamic_embedding.Variable` object to be restricted.
+    """
+    self.var = var
+    self.params_in_slots = []
+
+  def apply_update(self, ids):
+    """
+    Define the rule to update status, with tracking the
+    changes in variable and slots.
+
+    Args:
+      ids: A Tensor. Keys appear in training. These keys in status
+        variable will be updated if needed.
+
+    Returns:
+      An operation to update status.
+    """
+    raise NotImplementedError
+
+  def apply_restriction(self, num_reserved, **kwargs):
+    """
+    Define the rule to restrict the size of the target variable. There are
+    three kinds of variables are token into consideration: variable, status
+    variable, and variables in slots. Number of `num_reserved` features will
+    be kept in variable.
+
+    Args:
+      num_reserved: number of remained keys after restriction.
+      **kwargs: (Optional) reserved keyword arguments.
+
+    Returns:
+      An operation to restrict the sizes of variable and variables in slots.
+    """
+    raise NotImplementedError
+
+  @property
+  def status(self):
+    """
+    Get status variable which save information about properties of features.
+    """
+    return None
+
+  def _track_optimizer_slots(self, slots):
+    for _s in slots:
+      if isinstance(_s, de.TrainableWrapper):
+        params = _s.params
+      elif isinstance(_s, de.Variable):
+        params = _s
+      else:
+        raise TypeError('slots should be dynamic_embedding.TrainableWrapper'
+                        'or dynamic_embedding.Variable. But get {}'.format(
+                            type(_s)))
+      # TODO(Lifann) Use unique identifier instead of Python id().
+      id_collection = [id(p) for p in self.params_in_slots]
+      if id(params) not in id_collection:
+        self.params_in_slots.append(params)
+
+
+class TimestampRestrictPolicy(RestrictPolicy):
+  """
+  A derived policy to eliminate features in variable follow the
+  `oldest-out-first` rule.
+  """
+
+  def __init__(self, var):
+    """
+    A timestamp status sparse variable is created. The timestamp status
+    has same key_dtype as the target variable and value_dtype in int32,
+    which indicates the timestamp value. The timestamp means a digital
+    record of time. The later the time, the larger the timestamp.
+
+    Args:
+      var: A `dynamic_embedding.Variable` object to be restricted.
+    """
+    super(TimestampRestrictPolicy, self).__init__(var)
+    scope = variable_scope.get_variable_scope()
+    if scope.name:
+      tstp_scope = scope.name + '/status'
+    else:
+      tstp_scope = 'status'
+    tstp_name = self.var.name + '/timestamp'
+
+    with ops.name_scope(tstp_scope, 'status', []) as unique_scope:
+      if unique_scope:
+        full_name = unique_scope + tstp_name
+      else:
+        full_name = tstp_name
+
+      self.tstp_var = de.get_variable(
+          full_name,
+          key_dtype=self.var.key_dtype,
+          value_dtype=dtypes.int32,
+          dim=1,
+          devices=self.var.devices,
+          partitioner=self.var.partition_fn,
+          trainable=False,
+          init_size=self.var.init_size,
+      )
+
+  def apply_update(self, ids):
+    """
+    Define the rule to update the timestamp status. If any feature shows up
+    in training, then its timestamp will be updated.
+
+    Args:
+      ids: A Tensor. Keys appear in training. These keys in status variable
+        will be updated if needed.
+
+    Returns:
+      An operation to update timestamp status.
+    """
+    keys = array_ops.reshape(ids, (-1,))
+    fresh_tstp = array_ops.tile(
+        array_ops.reshape(gen_logging_ops.timestamp(), [1]),
+        array_ops.reshape(array_ops.size(keys), (-1,)),
+    )
+    fresh_tstp = math_ops.cast(fresh_tstp, dtypes.int32)
+    fresh_tstp = array_ops.reshape(fresh_tstp, (-1, 1))
+    update_tstp_op = self.tstp_var.upsert(keys, fresh_tstp)
+    return update_tstp_op
+
+  def apply_restriction(self, num_reserved, **kwargs):
+    """
+    Define the rule to restrict the size of the target variable by eliminating
+    the oldest k features, and number of `num_reserved` feature will be kept.
+
+    Args:
+      num_reserved: int. Number of remained keys after restriction.
+      **kwargs: (Optional) reserved keyword arguments.
+        trigger: int. The triggered threshold to execute restriction. Default
+          equals to `num_reserved`.
+
+    Returns:
+      An operation to restrict the sizes of variable and variables in slots.
+    """
+    if not isinstance(num_reserved, int):
+      raise TypeError('num_reserved should be integer.')
+    self._num_reserved = num_reserved
+    trigger = kwargs.get('trigger', num_reserved)
+    if not isinstance(trigger, int):
+      raise TypeError('trigger should be integer.')
+
+    is_oversize = math_ops.greater(self.var.size(), trigger)
+    return control_flow_ops.cond(is_oversize, self._cond_restrict_fn,
+                                 control_flow_ops.no_op)
+
+  def _cond_restrict_fn(self):
+    """
+    This will only be execute when size of variable is larger than trigger.
+    """
+    restrict_var_ops, restrict_status_ops, restrict_slot_ops = [], [], []
+    for i, dev in enumerate(self.tstp_var.devices):
+      with ops.device(dev):
+        partial_keys, partial_tstp = self.tstp_var.tables[i].export()
+        partial_reserved = int(self._num_reserved / self.tstp_var.shard_num)
+        partial_tstp = array_ops.reshape(partial_tstp, (-1,))
+        first_dim = array_ops.shape(partial_tstp)[0]
+
+        k_on_top = math_ops.cast(first_dim - partial_reserved,
+                                 dtype=dtypes.int32)
+        k_on_top = math_ops.maximum(k_on_top, 0)
+        _, removed_key_indices = nn_ops.top_k(-partial_tstp,
+                                              k_on_top,
+                                              sorted=False)
+        removed_keys = array_ops.gather(partial_keys, removed_key_indices)
+        restrict_var_ops.append(self.var.tables[i].remove(removed_keys))
+        restrict_status_ops.append(self.tstp_var.tables[i].remove(removed_keys))
+        for slot_param in self.params_in_slots:
+          restrict_slot_ops.append(slot_param.tables[i].remove(removed_keys))
+    return control_flow_ops.group(restrict_var_ops, restrict_status_ops,
+                                  restrict_slot_ops)
+
+  @property
+  def status(self):
+    return self.tstp_var
+
+
+class FrequencyRestrictPolicy(RestrictPolicy):
+  """
+  A derived policy to eliminate features in variable follow the
+  `lowest-occurrence-out-first` rule.
+  """
+
+  def __init__(self, var):
+    """
+    A frequency status sparse variable is created. The frequency status has
+    same key_dtype as the target variable and value_dtype in `int32`, which
+    indicates the occurrence times of the feature.
+
+    Args:
+      var: A `dynamic_embedding.Variable` object to be restricted.
+    """
+    super(FrequencyRestrictPolicy, self).__init__(var)
+    self.init_count = constant_op.constant(0, dtypes.int32)
+
+    scope = variable_scope.get_variable_scope()
+    if scope.name:
+      freq_scope = scope.name + '/status'
+    else:
+      freq_scope = 'status'
+    freq_name = self.var.name + '/frequency'
+
+    with ops.name_scope(freq_scope, 'status', []) as unique_scope:
+      if unique_scope:
+        full_name = unique_scope + freq_name
+      else:
+        full_name = freq_name
+
+      self.freq_var = de.get_variable(
+          full_name,
+          key_dtype=self.var.key_dtype,
+          value_dtype=dtypes.int32,
+          dim=1,
+          devices=self.var.devices,
+          partitioner=self.var.partition_fn,
+          trainable=False,
+          init_size=self.var.init_size,
+      )
+
+  def apply_update(self, ids):
+    """
+    Define the rule to update the frequency status. If any feature shows up,
+    then its frequency value will be increased by 1.
+
+    Args:
+      ids: A Tensor. Keys appear in training. These keys in status variable
+        will be updated if needed.
+
+    Returns:
+      An operation to update timestamp status.
+    """
+    update_status_ops = []
+    keys = array_ops.reshape(ids, (-1,))
+    partitioned_indices = self.var.partition_fn(keys, self.var.shard_num)
+    partitioned_keys, _ = make_partition(keys, partitioned_indices,
+                                         self.var.shard_num)
+    for i, dev in enumerate(self.freq_var.devices):
+      with ops.device(dev):
+        feature_counts = self.freq_var.tables[i].lookup(
+            partitioned_keys[i], dynamic_default_values=self.init_count)
+        feature_counts += 1
+        update_table_op = self.freq_var.tables[i].insert(
+            partitioned_keys[i], feature_counts)
+        update_status_ops.append(update_table_op)
+    return control_flow_ops.group(update_status_ops)
+
+  def apply_restriction(self, num_reserved, **kwargs):
+    """
+    Define the rule to restrict the size of the target variable by eliminating
+    k features with least occurrence, and number of `num_reserved` features will
+    be left.
+
+    Args:
+      num_reserved: int. Number of remained keys after restriction.
+      **kwargs: (Optional) reserved keyword arguments.
+        trigger: int. The triggered threshold to execute restriction. Default
+          equals to `num_reserved`.
+
+    Returns:
+      An operation to do restriction.
+    """
+    if not isinstance(num_reserved, int):
+      raise TypeError('num_reserved should be integer.')
+    if num_reserved < 0:
+      raise ValueError('num_reserved should be non-negative.')
+    self._num_reserved = num_reserved
+    trigger = kwargs.get('trigger', num_reserved)
+    if not isinstance(trigger, int):
+      raise TypeError('trigger should be integer.')
+
+    is_oversize = math_ops.greater(self.var.size(), trigger)
+    return control_flow_ops.cond(is_oversize, self._cond_restrict_fn,
+                                 control_flow_ops.no_op)
+
+  def _cond_restrict_fn(self):
+    """
+    This will only be execute when size of variable is larger than trigger.
+    """
+    restrict_var_ops, restrict_status_ops, restrict_slot_ops = [], [], []
+
+    for i, dev in enumerate(self.freq_var.devices):
+      with ops.device(dev):
+        partial_keys, partial_counts = self.freq_var.tables[i].export()
+        partial_reserved = int(self._num_reserved / self.freq_var.shard_num)
+        partial_counts = array_ops.reshape(partial_counts, (-1,))
+        first_dim = array_ops.shape(partial_counts)[0]
+
+        k_on_top = math_ops.cast(first_dim - partial_reserved,
+                                 dtype=dtypes.int32)
+        k_on_top = math_ops.maximum(k_on_top, 0)
+        _, removed_key_indices = nn_ops.top_k(-partial_counts,
+                                              k_on_top,
+                                              sorted=False)
+        removed_keys = array_ops.gather(partial_keys, removed_key_indices)
+
+        restrict_var_ops.append(self.var.tables[i].remove(removed_keys))
+        restrict_status_ops.append(self.freq_var.tables[i].remove(removed_keys))
+        for slot_param in self.params_in_slots:
+          restrict_slot_ops.append(slot_param.tables[i].remove(removed_keys))
+    return control_flow_ops.group(restrict_var_ops, restrict_status_ops,
+                                  restrict_slot_ops)
+
+  @property
+  def status(self):
+    return self.freq_var

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -1,4 +1,4 @@
-# Copyright 2020 The TensorFlow Recommenders-Addpnons Authors.
+# Copyright 2020 The TensorFlow Recommenders-Addons Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -51,6 +51,10 @@ class _DenseDynamicEmbeddingTrainableProcessor(optimizer._OptimizableVariable):
       _slots = [
           optimizer.get_slot(self._v, _s) for _s in optimizer.get_slot_names()
       ]
+      # Add the optimizer slots to restricting list.
+      if self._v.params.restrict_policy is not None:
+        self._v.params.restrict_policy._track_optimizer_slots(_slots)
+
       with ops.control_dependencies([g]):
         _before = [self._v.read_value()] + [_s.read_value() for _s in _slots]
       if isinstance(g, ops.IndexedSlices):


### PR DESCRIPTION
This PR provides the capability of tracking and restricting the sparse variables and optimizer slots in training.

# APIs
* [RestrictPolicy](): Abstract class which defines rules for tracking and updating the variables and optimizer slots.
* [TimestampRestrictPolicy](): Derived class from `RestrictPolicy` follow the "oldest-out-first" rule.
* [FrequencyRestrictPolicy](): Derived class from `RestrictPolicy` follow the "lowest-occurrence-out-first" rule.

# How To Use

  ### eager mode example:
  ```python
   var = dynamic_embedding.get_variable(
      'my_var',
      initializer=0.1,
      dim=8,
      restrict_policy=de.FrequencyRestrictPolicy)
  ...

  optimizer.minimize(loss_fn, var_fn)
  if step % 20 == 0:
    var.restrict(100, trigger=120)
  ```

  ### graph mode example:
  ```python
  var = dynamic_embedding.get_variable(
      'my_var',
      initializer=0.1,
      dim=8,
      restrict_policy=de.TimestampRestrictPolicy)
  ...
  optmizer = tf.train.AdagradOptimizer(0.1)
  train_op = optimizer.minimize(loss)
  restrict_op = var.restrict(100, trigger=120)

  with tf.compat.v1.Session() as sess:
    for step in range(num_ter):
      sess.run([train_op])
      if step % 20 == 0:
        sess.run(restrict_op)
  ```