### PR TITLE
Fix bazel build error with cuda

### DIFF
--- a/build_deps/toolchains/gpu/cuda_configure.bzl
+++ b/build_deps/toolchains/gpu/cuda_configure.bzl
@@ -1013,6 +1013,8 @@ def _create_local_cuda_repository(repository_ctx):
 
     builtin_include_directories = []
     for one_line in cuda_defines["%{host_compiler_includes}"].splitlines():
+        if len(one_line) == 0:
+            continue
         inc_dir = one_line.split(":")[1][2:-1]
         builtin_include_directories.append(inc_dir)
 


### PR DESCRIPTION
# Description
I tried to build a TF-GPU op under tfra/dynamic_embedding framework, but get error in [issue](https://github.com/tensorflow/recommenders-addons/issues/52).

There is a running error in building script, which ignore invalid environment string.

The problem is solved by this PR.