### PR TITLE
Support sparse_segment_sum ops on GPU.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ pip install tensorflow-recommenders-addons[tensorflow]
 ```
 
 Similar extras exist for the `tensorflow-gpu` and `tensorflow-cpu` packages.
+
+By default, install `tensorflow-recommenders-addons` with pip will download CPU version package and
+install. If you need to run on GPU, you could install the GPU version:
+```
+pip install tensorflow-recommenders-addons-gpu
+```
  
 
 To use TensorFlow Recommenders-Addons:
@@ -90,7 +96,7 @@ import tensorflow as tf
 import tensorflow_recommenders_addons as tfra
 ```
 
-### Compatility with Tensorflow
+### Compatibility with Tensorflow
 TensorFlow C++ APIs are not stable and thus we can only guarantee compatibility with the 
 version TensorFlow Recommenders-Addons(TFRA) was built against. It is possible TFRA will work with 
 multiple versions of TensorFlow, but there is also a chance for segmentation faults or other problematic 
@@ -115,6 +121,7 @@ If you need to work with other versions of TensorFlow, we recommend you installi
 
 
 #### Installing from Source
+##### CPU-only
 You can also install from source. This requires the [Bazel](https://bazel.build/) build system (version == 3.7.2).
 
 ```
@@ -130,7 +137,27 @@ bazel-bin/build_pip_pkg artifacts
 pip install artifacts/tensorflow_recommenders_addons-*.whl
 ```
 
-### Compatility with Tensorflow Serving
+##### GPU Support
+**Tensorflow Recommender-Addons** also supports to build on GPU. Please set the `TF_CUDA_VERSION`, `TF_CUDNN_VERSION`,
+`TF_NEED_CUDA`, and `CUDNN_INSTALL_PATH` in environment variables:
+```
+TF_CUDA_VERSION=11.0 TF_CUDNN_VERSION=8 TF_NEED_CUDA=1 CUDNN_INSTALL_PATH="/data/dev/packages/cuda" python configure.py
+```
+And then build the pip package and install:
+```
+bazel build --enable_runfiles build_pip_pkg
+bazel-bin/build_pip_pkg artifacts
+pip install artifacts/tensorflow_recommenders_addons-*.whl
+```
+
+##### Compatibility Matrix with GPU
+| TensorFlow Recommenders-Addons | TensorFlow | Compiler  | CUDNN | CUDA | Compute Capability |
+|:----------------------- |:---- |:---------| :------------ | :---- | :------------ |
+| tensorflow-recommenders-addons-0.1.0 | 2.4.1  | GCC 7.3.1 | 8.2.0 | 11.0 | [3.5, 5.2, 6.0, 6.1, 7.0, 7.5, 8.0] |
+
+Check [nvidia-support-matrix](https://docs.nvidia.com/deeplearning/cudnn/support-matrix/index.html) for more details.
+
+### Compatibility with Tensorflow Serving
 
 #### Compatibility Matrix
 | TensorFlow Recommenders-Addons | TensorFlow | Serving | Compiler  |

--- a/build_deps/tf_dependency/build_defs.bzl.tpl
+++ b/build_deps/tf_dependency/build_defs.bzl.tpl
@@ -2,6 +2,4 @@
 
 D_GLIBCXX_USE_CXX11_ABI = "%{tf_cx11_abi}"
 
-DTF_MAJOR_VERSION = "%{tf_major_version}"
-DTF_MINOR_VERSION = "%{tf_minor_version}"
-DTF_PATCH_VERSION = "%{tf_patch_version}"
+DTF_VERSION = "%{tf_version}"

--- a/build_deps/tf_dependency/build_defs.bzl.tpl
+++ b/build_deps/tf_dependency/build_defs.bzl.tpl
@@ -1,3 +1,7 @@
 # Addons Build Definitions inherited from TensorFlow Core
 
 D_GLIBCXX_USE_CXX11_ABI = "%{tf_cx11_abi}"
+
+DTF_MAJOR_VERSION = "%{tf_major_version}"
+DTF_MINOR_VERSION = "%{tf_minor_version}"
+DTF_PATCH_VERSION = "%{tf_patch_version}"

--- a/build_deps/tf_dependency/tf_configure.bzl
+++ b/build_deps/tf_dependency/tf_configure.bzl
@@ -8,6 +8,12 @@ _TF_SHARED_LIBRARY_NAME = "TF_SHARED_LIBRARY_NAME"
 
 _TF_CXX11_ABI_FLAG = "TF_CXX11_ABI_FLAG"
 
+TF_MAJOR_VERSION = "TF_MAJOR_VERSION"
+
+TF_MINOR_VERSION = "TF_MINOR_VERSION"
+
+TF_PATCH_VERSION = "TF_PATCH_VERSION"
+
 def _tpl(repository_ctx, tpl, substitutions = {}, out = None):
     if not out:
         out = tpl
@@ -204,6 +210,9 @@ def _tf_pip_impl(repository_ctx):
     tf_shared_library_name = repository_ctx.os.environ[_TF_SHARED_LIBRARY_NAME]
     tf_shared_library_path = "%s/%s" % (tf_shared_library_dir, tf_shared_library_name)
     tf_cx11_abi = "-D_GLIBCXX_USE_CXX11_ABI=%s" % (repository_ctx.os.environ[_TF_CXX11_ABI_FLAG])
+    tf_major_version = "-DTF_MAJOR_VERSION=%s" % (repository_ctx.os.environ[TF_MAJOR_VERSION])
+    tf_minor_version = "-DTF_MINOR_VERSION=%s" % (repository_ctx.os.environ[TF_MINOR_VERSION])
+    tf_patch_version = "-DTF_PATCH_VERSION=%s" % (repository_ctx.os.environ[TF_PATCH_VERSION])
 
     tf_shared_library_rule = _symlink_genrule_for_dir(
         repository_ctx,
@@ -225,6 +234,9 @@ def _tf_pip_impl(repository_ctx):
         "build_defs.bzl",
         {
             "%{tf_cx11_abi}": tf_cx11_abi,
+            "%{tf_major_version}": tf_major_version,
+            "%{tf_minor_version}": tf_minor_version,
+            "%{tf_patch_version}": tf_patch_version,
         },
     )
 

--- a/build_deps/tf_dependency/tf_configure.bzl
+++ b/build_deps/tf_dependency/tf_configure.bzl
@@ -8,11 +8,7 @@ _TF_SHARED_LIBRARY_NAME = "TF_SHARED_LIBRARY_NAME"
 
 _TF_CXX11_ABI_FLAG = "TF_CXX11_ABI_FLAG"
 
-TF_MAJOR_VERSION = "TF_MAJOR_VERSION"
-
-TF_MINOR_VERSION = "TF_MINOR_VERSION"
-
-TF_PATCH_VERSION = "TF_PATCH_VERSION"
+TF_VERSION = "TF_VERSION"
 
 def _tpl(repository_ctx, tpl, substitutions = {}, out = None):
     if not out:
@@ -210,9 +206,7 @@ def _tf_pip_impl(repository_ctx):
     tf_shared_library_name = repository_ctx.os.environ[_TF_SHARED_LIBRARY_NAME]
     tf_shared_library_path = "%s/%s" % (tf_shared_library_dir, tf_shared_library_name)
     tf_cx11_abi = "-D_GLIBCXX_USE_CXX11_ABI=%s" % (repository_ctx.os.environ[_TF_CXX11_ABI_FLAG])
-    tf_major_version = "-DTF_MAJOR_VERSION=%s" % (repository_ctx.os.environ[TF_MAJOR_VERSION])
-    tf_minor_version = "-DTF_MINOR_VERSION=%s" % (repository_ctx.os.environ[TF_MINOR_VERSION])
-    tf_patch_version = "-DTF_PATCH_VERSION=%s" % (repository_ctx.os.environ[TF_PATCH_VERSION])
+    tf_version = "-DTF_VERSION=%s" % (repository_ctx.os.environ[TF_VERSION])
 
     tf_shared_library_rule = _symlink_genrule_for_dir(
         repository_ctx,
@@ -234,9 +228,7 @@ def _tf_pip_impl(repository_ctx):
         "build_defs.bzl",
         {
             "%{tf_cx11_abi}": tf_cx11_abi,
-            "%{tf_major_version}": tf_major_version,
-            "%{tf_minor_version}": tf_minor_version,
-            "%{tf_patch_version}": tf_patch_version,
+            "%{tf_version}": tf_version,
         },
     )
 

--- a/build_deps/toolchains/gpu/cuda_configure.bzl
+++ b/build_deps/toolchains/gpu/cuda_configure.bzl
@@ -53,11 +53,11 @@ _PYTHON_BIN_PATH = "PYTHON_BIN_PATH"
 _DEFAULT_CUDA_COMPUTE_CAPABILITIES = [
     "3.5",
     "5.2",
+    "6.0",
     "6.1",
     "7.0",
     "7.5",
     "8.0",
-    "8.6",
 ]
 
 def _get_python_bin(repository_ctx):

--- a/configure.py
+++ b/configure.py
@@ -92,6 +92,15 @@ def get_shared_lib_name():
     return namespec[1][3:]
 
 
+def get_tf_version():
+  version = tf.__version__
+  try:
+    major, minor, patch = version.split('.')
+  except:
+    raise ValueError('got wrong tf.__version__: {}'.format(version))
+  return version, major, minor, patch
+
+
 def create_build_configuration():
   print()
   print("Configuring TensorFlow Recommenders-Addons to be built from source...")
@@ -105,6 +114,13 @@ def create_build_configuration():
   write_action_env("TF_SHARED_LIBRARY_DIR", get_tf_shared_lib_dir())
   write_action_env("TF_SHARED_LIBRARY_NAME", get_shared_lib_name())
   write_action_env("TF_CXX11_ABI_FLAG", tf.sysconfig.CXX11_ABI_FLAG)
+
+  _, tf_major_version, tf_minor_version, tf_patch_version = get_tf_version()
+  # This is used to trace the difference between Tensorflow versions.
+  # TODO(Lifann) write them to enviroment variables.
+  write_action_env("TF_MAJOR_VERSION", tf_major_version)
+  write_action_env("TF_MINOR_VERSION", tf_minor_version)
+  write_action_env("TF_PATCH_VERSION", tf_patch_version)
 
   write("build --spawn_strategy=standalone")
   write("build --strategy=Genrule=standalone")

--- a/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
@@ -14,6 +14,7 @@
 # ==============================================================================
 """Export dynamic_embedding APIs."""
 
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops import math_ops as math
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.cuckoo_hashtable_ops import (
     CuckooHashTable,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_optimizer import (
@@ -42,13 +43,13 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embeddi
     get_variable,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
     Variable,)
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
+    GraphKeys,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.restrict_policies import (
     RestrictPolicy,
     TimestampRestrictPolicy,
     FrequencyRestrictPolicy,
 )
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
-    GraphKeys,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_patch import (
     patch_on_tf,)
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/BUILD
@@ -5,6 +5,7 @@ load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda", "if_cuda_is_configure
 package(default_visibility = ["//visibility:public"])
 
 load("//tensorflow_recommenders_addons:tensorflow_recommenders_addons.bzl", "custom_op_library")
+load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda")
 
 custom_op_library(
     name = "_cuckoo_hashtable_ops.so",
@@ -19,4 +20,18 @@ custom_op_library(
         "kernels/cuckoo_hashtable_op_gpu.cu.cc",
     ] + glob(["kernels/lookup_impl/lookup_table_op_gpu*"])),
     deps = ["//tensorflow_recommenders_addons/dynamic_embedding/core/lib/cuckoo:cuckoohash"],
+)
+
+custom_op_library(
+    name = "_segment_reduction_ops.so",
+    srcs = [
+        "kernels/segment_reduction_ops.h",
+        "kernels/segment_reduction_ops_impl.cc",
+        "kernels/segment_reduction_ops_impl.h",
+        "ops/math_ops.cc",
+    ],
+    cuda_srcs = [
+        "kernels/segment_reduction_ops.h",
+        "kernels/segment_reduction_ops_gpu.cu.cc",
+    ],
 )

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops.h
@@ -1,0 +1,65 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef TFRA_CORE_KERNELS_SEGMENT_REDUCTION_OPS_H_
+#define TFRA_CORE_KERNELS_SEGMENT_REDUCTION_OPS_H_
+
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_shape.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+namespace tensorflow {
+
+class OpKernelContext;
+
+namespace functor {
+
+typedef Eigen::GpuDevice GPUDevice;
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+template <typename T, typename Index>
+struct SparseSegmentSumFunctor {
+  const Index output_rows;
+  const Index num_indices;
+  const Index data_size;
+  const Tensor& input;
+  const Tensor& indices;
+  const Tensor& segment_ids;
+  Tensor* output;
+
+  explicit SparseSegmentSumFunctor(const Index output_rows,
+                                   const Index num_indices,
+                                   const Index data_size,
+                                   const Tensor& input_data,
+                                   const Tensor& indices,
+                                   const Tensor& segment_ids, Tensor* output)
+      : output_rows(output_rows),
+        num_indices(num_indices),
+        data_size(data_size),
+        input(input_data),
+        indices(indices),
+        segment_ids(segment_ids),
+        output(output) {}
+
+  void operator()(OpKernelContext* ctx, const GPUDevice& d);
+};
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // TFRA_CORE_KERNELS_SEGMENT_REDUCTION_OPS_H_

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_gpu.cu.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_gpu.cu.cc
@@ -1,0 +1,136 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#define EIGEN_USE_GPU
+
+#include "segment_reduction_ops.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/util/gpu_device_functions.h"
+#include "tensorflow/core/util/gpu_kernel_helper.h"
+
+namespace tensorflow {
+
+using GPUDevice = Eigen::GpuDevice;
+
+template <typename T, typename Index, int OuterDimTileSize>
+__global__ void SortedSparseSegmentSumCustomKernel(
+    const Index input_outer_dim_size, const Index inner_dim_size,
+    const Index output_outer_dim_size, const Index* indices,
+    const Index* segment_ids, const T* input, T* output,
+    const Index total_stripe_count) {
+  for (int stripe_index : GpuGridRangeX(total_stripe_count)) {
+    const Index segment_offset = stripe_index % inner_dim_size;
+    const Index input_outer_dim_index_base =
+        stripe_index / inner_dim_size * Index(OuterDimTileSize);
+
+    T sum = T(0);
+    Index first_segment_id = segment_ids[input_outer_dim_index_base];
+    Index last_output_segment_id = output_outer_dim_size;
+
+    const Index actual_stripe_height =
+        min(Index(OuterDimTileSize),
+            input_outer_dim_size - input_outer_dim_index_base);
+    for (Index j = 0; j < actual_stripe_height; j++) {
+      Index current_output_segment_id =
+          segment_ids[input_outer_dim_index_base + j];
+      Index current_input_index_id = indices[input_outer_dim_index_base + j];
+
+      if (current_output_segment_id > last_output_segment_id) {
+        const Index output_index =
+            last_output_segment_id * inner_dim_size + segment_offset;
+        if (last_output_segment_id == first_segment_id) {
+          GpuAtomicAdd(output + output_index, sum);
+        } else {
+          *(output + output_index) = sum;
+        }
+        sum = T(0);
+      }
+      sum +=
+          ldg(input + current_input_index_id * inner_dim_size + segment_offset);
+      last_output_segment_id = current_output_segment_id;
+    }
+
+    const Index output_index =
+        last_output_segment_id * inner_dim_size + segment_offset;
+    GpuAtomicAdd(output + output_index, sum);
+  }
+}
+
+namespace functor {
+
+// TODO(Lifann): enable indices validation on GPU. Right now
+// checking for indicies out of bound in the kernel would
+// require copying code between GPU/CPU, and thus slow.
+template <typename T, typename Index>
+void SparseSegmentSumFunctor<T, Index>::operator()(OpKernelContext* ctx,
+                                                   const GPUDevice& d) {
+  auto stream = ctx->op_device_context()->stream();
+  auto output_flat = output->flat_outer_dims<T>();
+  auto data_ptr = input.template flat<T>().data();
+  const auto indices_flat = indices.flat<Index>();
+  const auto segment_flat = segment_ids.flat<Index>();
+
+  if (output_flat.size() == 0) {
+    return;
+  }
+
+  GpuLaunchConfig config = GetGpuLaunchConfig(output_flat.size(), d);
+  TF_CHECK_OK(GpuLaunchKernel(SetZero<T>, config.block_count,
+                              config.thread_per_block, 0, d.stream(),
+                              output_flat.size(), output_flat.data()));
+  if (data_size == 0 || segment_ids.shape().num_elements() == 0) {
+    return;
+  }
+
+  const Index input_total_size = data_size;
+  const Index input_outer_dim_size = segment_flat.dimension(0);
+  const Index input_inner_dim_size = input_total_size / input_outer_dim_size;
+  const int OuterDimTileSize = 8;
+
+  const Index input_outer_dim_num_stripe =
+      Eigen::divup(input_outer_dim_size, Index(OuterDimTileSize));
+
+  const Index total_stripe_count =
+      input_inner_dim_size * input_outer_dim_num_stripe;
+
+  if (total_stripe_count <= 0) return;
+  config = GetGpuLaunchConfig(total_stripe_count, d);
+  TF_CHECK_OK(GpuLaunchKernel(
+      SortedSparseSegmentSumCustomKernel<T, Index, OuterDimTileSize>,
+      config.block_count, config.thread_per_block, 0, d.stream(),
+      input_outer_dim_size, input_inner_dim_size, output_rows,
+      indices_flat.data(), segment_flat.data(), data_ptr, output_flat.data(),
+      total_stripe_count));
+}
+
+#define DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS_INDEX(T, Index) \
+  template struct SparseSegmentSumFunctor<T, Index>
+
+#define DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS(T)         \
+  DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS_INDEX(T, int32); \
+  DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS_INDEX(T, int64);
+
+TF_CALL_GPU_NUMBER_TYPES(DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS);
+
+#undef DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS
+#undef DEFINE_SPARSE_SEGMENT_SUM_GPU_SPECS_INDEX
+
+}  // namespace functor
+
+}  // namespace tensorflow
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_impl.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_impl.cc
@@ -1,0 +1,59 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/math_ops.cc.
+#include "segment_reduction_ops_impl.h"
+
+namespace tensorflow {
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#define REGISTER_GPU_SORTED_KERNELS(type, index_type)                        \
+  REGISTER_KERNEL_BUILDER(Name("TFRA>SparseSegmentSum")                      \
+                              .Device(DEVICE_GPU)                            \
+                              .TypeConstraint<type>("T")                     \
+                              .TypeConstraint<index_type>("Tidx"),           \
+                          SparseSegmentSumGpuOp<GPUDevice, type, index_type, \
+                                                /*has_num_segments=*/false>)
+
+#define REGISTER_GPU_SORTED_KERNELS_ALL(type) \
+  REGISTER_GPU_SORTED_KERNELS(type, int32);   \
+  REGISTER_GPU_SORTED_KERNELS(type, int64);
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SORTED_KERNELS_ALL);
+
+#undef REGISTER_GPU_SORTED_KERNELS
+#undef REGISTER_GPU_SORTED_KERNELS_ALL
+
+#define REGISTER_GPU_SORTED_KERNELS(type, index_type)                        \
+  REGISTER_KERNEL_BUILDER(Name("TFRA>SparseSegmentSumWithNumSegments")       \
+                              .Device(DEVICE_GPU)                            \
+                              .HostMemory("num_segments")                    \
+                              .TypeConstraint<type>("T")                     \
+                              .TypeConstraint<index_type>("Tidx"),           \
+                          SparseSegmentSumGpuOp<GPUDevice, type, index_type, \
+                                                /*has_num_segments=*/true>)
+
+#define REGISTER_GPU_SORTED_KERNELS_ALL(type) \
+  REGISTER_GPU_SORTED_KERNELS(type, int32);   \
+  REGISTER_GPU_SORTED_KERNELS(type, int64);
+
+TF_CALL_GPU_NUMBER_TYPES(REGISTER_GPU_SORTED_KERNELS_ALL);
+
+#undef REGISTER_GPU_SORTED_KERNELS
+#undef REGISTER_GPU_SORTED_KERNELS_ALL
+
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+}  // namespace tensorflow

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_impl.h
@@ -49,7 +49,11 @@ limitations under the License.
 #endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
 
 #if GOOGLE_CUDA
+#if TF_VERSION >= 2040  // 2.4.0
 #include "tensorflow/core/util/cuda_solvers.h"
+#else
+#include "tensorflow/core/kernels/cuda_solvers.h"
+#endif  // TF_VERSION >= 2040
 #include "tensorflow/stream_executor/cuda/cuda_activation.h"
 
 using stream_executor::cuda::ScopedActivateExecutorContext;

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_impl.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/segment_reduction_ops_impl.h
@@ -1,0 +1,162 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// See docs in ../ops/math_ops.cc.
+
+#ifndef TFRA_CORE_KERNELS_SEGMENT_REDUCTION_OPS_IMPL_H_
+#define TFRA_CORE_KERNELS_SEGMENT_REDUCTION_OPS_IMPL_H_
+
+#define EIGEN_USE_THREADS
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#define EIGEN_USE_GPU
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#include <stdio.h>
+#include <unistd.h>
+
+#include <vector>
+
+#include "segment_reduction_ops.h"
+#include "tensorflow/core/framework/bounds_check.h"
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op_kernel.h"
+#include "tensorflow/core/framework/register_types.h"
+#include "tensorflow/core/framework/tensor.h"
+#include "tensorflow/core/framework/tensor_types.h"
+#include "tensorflow/core/framework/tensor_util.h"
+#include "tensorflow/core/framework/types.h"
+#include "tensorflow/core/kernels/segment_reduction_ops.h"
+#include "tensorflow/core/lib/core/status.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/util/util.h"
+#include "third_party/eigen3/Eigen/Core"
+#include "third_party/eigen3/unsupported/Eigen/CXX11/Tensor"
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+#include "tensorflow/core/common_runtime/gpu/gpu_event_mgr.h"
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+#if GOOGLE_CUDA
+#include "tensorflow/core/util/cuda_solvers.h"
+#include "tensorflow/stream_executor/cuda/cuda_activation.h"
+
+using stream_executor::cuda::ScopedActivateExecutorContext;
+#elif TENSORFLOW_USE_ROCM
+#include "tensorflow/core/platform/rocm.h"
+#include "tensorflow/core/util/cuda_solvers.h"
+using stream_executor::rocm::ScopedActivateExecutorContext;
+#endif  // GOOGLE_CUDA
+
+namespace tensorflow {
+
+typedef Eigen::ThreadPoolDevice CPUDevice;
+typedef Eigen::GpuDevice GPUDevice;
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+template <class Device, class T, class Tindex, bool has_num_segments>
+class SparseSegmentSumGpuOp : public AsyncOpKernel {
+ public:
+  explicit SparseSegmentSumGpuOp(OpKernelConstruction* context)
+      : AsyncOpKernel(context){};
+
+  void ComputeAsync(OpKernelContext* context, DoneCallback done) override {
+    const Tensor& input_data = context->input(0);
+    const Tensor& indices = context->input(1);
+    const Tensor& segment_ids = context->input(2);
+
+    OP_REQUIRES_ASYNC(context, TensorShapeUtils::IsVector(indices.shape()),
+                      errors::InvalidArgument("indices should be a vector."),
+                      done);
+    const int64 num_indices = indices.NumElements();
+
+    OP_REQUIRES_ASYNC(
+        context, TensorShapeUtils::IsVector(segment_ids.shape()),
+        errors::InvalidArgument("segment_ids should be a vector."), done);
+
+    OP_REQUIRES_ASYNC(
+        context, num_indices == segment_ids.NumElements(),
+        errors::InvalidArgument("indices and segment_ids should have"
+                                "same length."),
+        done);
+
+    ScratchSpace<Tindex> output_rows_host(context, /*size=*/1,
+                                          /*on_host=*/true);
+    auto stream = context->op_device_context()->stream();
+
+    if (has_num_segments) {
+      const Tensor& num_segments = context->input(3);
+      output_rows_host.tensor().CopyFrom(num_segments, num_segments.shape());
+    } else {
+      se::DeviceMemoryBase last_segment_id_on_device(
+          reinterpret_cast<Tindex*>(segment_ids.data()) + num_indices - 1);
+      OP_REQUIRES_ASYNC(
+          context,
+          stream
+              ->ThenMemcpy(output_rows_host.mutable_data(),
+                           last_segment_id_on_device, sizeof(Tindex))
+              .ok(),
+          errors::Internal(
+              "SparseSegmentSumGpuOp: failed to copy output_rows to host."),
+          done);
+    }
+
+    const Tindex input_dims = input_data.dims();
+    OP_REQUIRES_ASYNC(
+        context, input_dims >= 1,
+        errors::InvalidArgument("indices and segment_ids should have "
+                                "same length."),
+        done);
+
+    Tindex element_size = 1;
+    const TensorShape input_shape = input_data.shape();
+    if (input_dims > 1) {
+      for (Tindex i = 1; i < input_dims; i++) {
+        element_size *= input_shape.dim_size(i);
+      }
+    }
+
+    OP_REQUIRES_OK_ASYNC(context, stream->BlockHostUntilDone(), done);
+    Tindex output_rows = *output_rows_host.data();
+    // Since segment_ids counts from 0 for output position, the output_rows
+    // is increased by 1, if there is no specified num_segments value.
+    if (!has_num_segments) {
+      output_rows++;
+    }
+    OP_REQUIRES_ASYNC(context, output_rows > 0,
+                      errors::InvalidArgument("Segment ids must be >= 0"),
+                      done);
+    TensorShape output_shape = input_data.shape();
+    output_shape.set_dim(0, output_rows);
+
+    Tensor* output = nullptr;
+    OP_REQUIRES_OK_ASYNC(
+        context, context->allocate_output(0, output_shape, &output), done);
+
+    functor::SparseSegmentSumFunctor<T, Tindex> executant(
+        output_rows, num_indices, num_indices * element_size, input_data,
+        indices, segment_ids, output);
+
+    ScopedActivateExecutorContext scoped_activation{stream->parent()};
+    executant(context, context->eigen_device<GPUDevice>());
+
+    context->device()->tensorflow_gpu_device_info()->event_mgr->ThenExecute(
+        stream, done);
+  }
+};
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+}  // namespace tensorflow
+
+#endif  // TFRA_CORE_KERNELS_SEGMENT_REDUCTION_OPS_IMPL_H_

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/math_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/math_ops.cc
@@ -1,0 +1,118 @@
+/* Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#include "tensorflow/core/framework/common_shape_fns.h"
+#include "tensorflow/core/framework/numeric_op.h"
+#include "tensorflow/core/framework/op.h"
+#include "tensorflow/core/framework/shape_inference.h"
+
+namespace tensorflow {
+
+using shape_inference::DimensionHandle;
+using shape_inference::InferenceContext;
+using shape_inference::ShapeAndType;
+using shape_inference::ShapeHandle;
+
+namespace {
+
+Status SparseSegmentReductionShapeFn(InferenceContext* c) {
+  ShapeHandle data_shape;
+  TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &data_shape));
+
+  ShapeHandle indices_shape;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &indices_shape));
+
+  ShapeHandle segment_ids_shape;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &segment_ids_shape));
+
+  // indices and segment_ids should merge cleanly.
+  ShapeHandle unused;
+  TF_RETURN_IF_ERROR(c->Merge(indices_shape, segment_ids_shape, &unused));
+
+  ShapeHandle subshape;
+  TF_RETURN_IF_ERROR(c->Subshape(data_shape, 1, &subshape));
+
+  ShapeHandle out;
+  TF_RETURN_IF_ERROR(
+      c->Concatenate(c->Vector(InferenceContext::kUnknownDim), subshape, &out));
+  c->set_output(0, out);
+  return Status::OK();
+}
+
+Status SparseSegmentReductionWithNumSegmentsShapeFn(InferenceContext* c) {
+  ShapeHandle data_shape;
+  TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(0), 1, &data_shape));
+
+  ShapeHandle indices_shape;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &indices_shape));
+
+  ShapeHandle segment_ids_shape;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(2), 1, &segment_ids_shape));
+
+  ShapeHandle num_segments_shape;
+  TF_RETURN_IF_ERROR(c->WithRank(c->input(3), 0, &num_segments_shape));
+
+  // indices and segment_ids should merge cleanly.
+  ShapeHandle unused;
+  TF_RETURN_IF_ERROR(c->Merge(indices_shape, segment_ids_shape, &unused));
+
+  ShapeHandle subshape;
+  TF_RETURN_IF_ERROR(c->Subshape(data_shape, 1, &subshape));
+
+  ShapeHandle out;
+  const Tensor* dim0 = c->input_tensor(3);
+  if (dim0 == nullptr) {
+    // We don't have the value at inference time, so the output
+    // shape is unknown.
+    TF_RETURN_IF_ERROR(c->Concatenate(c->Vector(InferenceContext::kUnknownDim),
+                                      subshape, &out));
+  } else {
+    auto dim0_value = dim0->scalar<int32>()();
+    if (dim0_value < 0) {
+      return errors::InvalidArgument(
+          "Cannot specify a negative value for num_segments");
+    }
+    TF_RETURN_IF_ERROR(c->Concatenate(c->Vector(dim0_value), subshape, &out));
+  }
+  c->set_output(0, out);
+  return Status::OK();
+}
+}  // namespace
+
+#if GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+REGISTER_OP("TFRA>SparseSegmentSum")
+    .Input("data: T")
+    .Input("indices: Tidx")
+    .Input("segment_ids: Tsegmentids")
+    .Output("output: T")
+    .Attr("T: realnumbertype")
+    .Attr("Tidx: {int32, int64} = DT_INT32")
+    .Attr("Tsegmentids: {int32, int64} = DT_INT32")
+    .SetShapeFn(SparseSegmentReductionShapeFn);
+
+REGISTER_OP("TFRA>SparseSegmentSumWithNumSegments")
+    .Input("data: T")
+    .Input("indices: Tidx")
+    .Input("segment_ids: Tsegmentids")
+    .Input("num_segments: Tnumsegments")
+    .Output("output: T")
+    .Attr("T: realnumbertype")
+    .Attr("Tidx: {int32, int64} = DT_INT32")
+    .Attr("Tnumsegments: {int32,int64} = DT_INT32")
+    .Attr("Tsegmentids: {int32, int64} = DT_INT32")
+    .SetShapeFn(SparseSegmentReductionWithNumSegmentsShapeFn);
+#endif  // GOOGLE_CUDA || TENSORFLOW_USE_ROCM
+
+}  // namespace tensorflow

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/BUILD
@@ -59,3 +59,23 @@ py_test(
         "//tensorflow_recommenders_addons",
     ],
 )
+
+py_test(
+    name = "math_ops_test",
+    srcs = ["math_ops_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_recommenders_addons",
+    ],
+)
+
+py_test(
+    name = "math_grad_test",
+    srcs = ["math_grad_test.py"],
+    python_version = "PY3",
+    srcs_version = "PY3",
+    deps = [
+        "//tensorflow_recommenders_addons",
+    ],
+)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/math_grad_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/math_grad_test.py
@@ -1,0 +1,91 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""unit tests of cuckoo hashtable ops
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops import math_ops as de_math
+
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.eager import backprop
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+default_config = config_pb2.ConfigProto(
+    allow_soft_placement=False,
+    gpu_options=config_pb2.GPUOptions(allow_growth=True))
+
+use_gpu = test_util.is_gpu_available()
+
+
+class SparseSemgentReductionGradOpsTestBase(object):
+
+  def backward_compute(self, data, indices, segment_ids, num_segments=None):
+    with backprop.GradientTape(persistent=True) as tape:
+      tape.watch(data)
+      result = de_math.sparse_segment_sum(data,
+                                          indices,
+                                          segment_ids,
+                                          num_segments=num_segments)
+      expected = math_ops.sparse_segment_sum(data,
+                                             indices,
+                                             segment_ids,
+                                             num_segments=num_segments)
+    result = tape.gradient(result, data)
+    expected = tape.gradient(expected, data)
+    return result, expected
+
+
+class SparseSegmentSumGpuGradTest(test.TestCase,
+                                  SparseSemgentReductionGradOpsTestBase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_value(self):
+    with self.session(use_gpu=use_gpu, config=default_config):
+      data = constant_op.constant(
+          [[1, 2, 3, 4], [-1, -2, -3, -4], [5, 6, 7, 8]], dtype=dtypes.float32)
+      indices = constant_op.constant([0, 1], dtype=dtypes.int32)
+      segment_ids = constant_op.constant([0, 5], dtype=dtypes.int32)
+      result, expected = self.backward_compute(data, indices, segment_ids)
+
+      self.assertAllEqual(self.evaluate(result), self.evaluate(expected))
+
+
+class SparseSegmentSumGpuGradTest(test.TestCase,
+                                  SparseSemgentReductionGradOpsTestBase):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_value(self):
+    with self.session(use_gpu=use_gpu, config=default_config):
+      data = constant_op.constant(
+          [[1, 2, 3, 4], [-1, -2, -3, -4], [5, 6, 7, 8]], dtype=dtypes.float32)
+      indices = constant_op.constant([0, 1], dtype=dtypes.int32)
+      segment_ids = constant_op.constant([0, 5], dtype=dtypes.int32)
+      num_segments = 100
+      result, expected = self.backward_compute(data,
+                                               indices,
+                                               segment_ids,
+                                               num_segments=num_segments)
+
+      self.assertAllEqual(self.evaluate(result), self.evaluate(expected))
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/math_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/math_ops_test.py
@@ -1,0 +1,112 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""unit tests of cuckoo hashtable ops
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops import math_ops as de_math
+
+from tensorflow.core.protobuf import config_pb2
+from tensorflow.python.framework import constant_op
+from tensorflow.python.framework import dtypes
+from tensorflow.python.framework import test_util
+from tensorflow.python.framework import errors
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.platform import test
+
+default_config = config_pb2.ConfigProto(
+    allow_soft_placement=False,
+    gpu_options=config_pb2.GPUOptions(allow_growth=True))
+
+use_gpu = test_util.is_gpu_available()
+
+
+class SparseSemgentReductionOpsTest(object):
+
+  def forward_compute(self, data, indices, segment_ids, num_segments=None):
+    result = de_math.sparse_segment_sum(data,
+                                        indices,
+                                        segment_ids,
+                                        num_segments=num_segments)
+    expected = math_ops.sparse_segment_sum(data,
+                                           indices,
+                                           segment_ids,
+                                           num_segments=num_segments)
+    return result, expected
+
+
+class SparseSegmentSumGpuTest(test.TestCase, SparseSemgentReductionOpsTest):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_not_equal_indices_and_seg_ids_num(self):
+    with self.session(use_gpu=use_gpu, config=default_config):
+      data = constant_op.constant(list(range(20)), dtype=dtypes.float32)
+      data = array_ops.reshape(data, (10, 2))
+      indices = constant_op.constant(list(range(6)), dtype=dtypes.int32)
+      segment_ids = constant_op.constant(list(range(7)), dtype=dtypes.int32)
+      with self.assertRaises((ValueError, errors.InvalidArgumentError)):
+        target = de_math.sparse_segment_sum(data, indices, segment_ids)
+        self.evaluate(target)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_value(self):
+    with self.session(use_gpu=use_gpu, config=default_config):
+      data = constant_op.constant(
+          [[1, 2, 3, 4], [-1, -2, -3, -4], [5, 6, 7, 8]], dtype=dtypes.float32)
+      indices = constant_op.constant([0, 1], dtype=dtypes.int32)
+      segment_ids = constant_op.constant([0, 5], dtype=dtypes.int32)
+      result, expected = self.forward_compute(data, indices, segment_ids)
+      self.assertAllEqual(self.evaluate(result), self.evaluate(expected))
+
+
+class SparseSegmentSumWithNumSegmentsGpuTest(test.TestCase,
+                                             SparseSemgentReductionOpsTest):
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_not_equal_indices_and_seg_ids_num(self):
+    with self.session(use_gpu=use_gpu, config=default_config):
+      data = constant_op.constant(list(range(20)), dtype=dtypes.float32)
+      data = array_ops.reshape(data, (10, 2))
+      indices = constant_op.constant(list(range(6)), dtype=dtypes.int32)
+      segment_ids = constant_op.constant(list(range(7)), dtype=dtypes.int32)
+      num_segments = 100
+      with self.assertRaises((ValueError, errors.InvalidArgumentError)):
+        target = de_math.sparse_segment_sum(data,
+                                            indices,
+                                            segment_ids,
+                                            num_segments=num_segments)
+        self.evaluate(target)
+
+  @test_util.run_in_graph_and_eager_modes
+  def test_value(self):
+    with self.session(use_gpu=use_gpu, config=default_config):
+      data = constant_op.constant(
+          [[1, 2, 3, 4], [-1, -2, -3, -4], [5, 6, 7, 8]], dtype=dtypes.float32)
+      indices = constant_op.constant([0, 1], dtype=dtypes.int32)
+      segment_ids = constant_op.constant([0, 5], dtype=dtypes.int32)
+      num_segments = 100
+      result, expected = self.forward_compute(data,
+                                              indices,
+                                              segment_ids,
+                                              num_segments=num_segments)
+
+      self.assertAllEqual(self.evaluate(result), self.evaluate(expected))
+
+
+if __name__ == "__main__":
+  test.main()

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/restrict_policies_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/restrict_policies_test.py
@@ -304,6 +304,7 @@ class FrequencyRestrictPolicyV1Test(test.TestCase, RestrictPolicyV1TestBase):
       for v in all_vars:
         self.assertAllEqual(sess.run(v.size()), len(updated_features))
       keys, _ = sess.run(var.export())
+      keys = np.sort(keys)
       self.assertAllEqual(keys, updated_features)
 
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/BUILD
@@ -13,6 +13,7 @@ py_library(
     srcs = glob(["*.py"]),
     data = [
         "//tensorflow_recommenders_addons/dynamic_embedding/core:_cuckoo_hashtable_ops.so",
+        "//tensorflow_recommenders_addons/dynamic_embedding/core:_segment_reduction_ops.so",
     ],
     srcs_version = "PY2AND3",
 )

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -711,10 +711,10 @@ def embedding_lookup_sparse(
     else:
       assert idx is not None
       if combiner == "sum":
-        embeddings = math_ops.sparse_segment_sum(embeddings,
-                                                 idx,
-                                                 segment_ids,
-                                                 name=name)
+        embeddings = de.math.sparse_segment_sum(embeddings,
+                                                idx,
+                                                segment_ids,
+                                                name=name)
       elif combiner == "mean":
         embeddings = math_ops.sparse_segment_mean(embeddings,
                                                   idx,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/math_grad.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/math_grad.py
@@ -1,0 +1,40 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""gradients for math operations."""
+# pylint: disable=g-bad-name
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+from tensorflow.python.framework import ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import array_ops
+
+
+@ops.RegisterGradient("TFRA>SparseSegmentSum")
+def _TfraSparseSegmentSumGrad(op, grad):
+  """Gradient for TFRA>SparseSegmentSum."""
+  input_rows = array_ops.shape(op.inputs[0])[0]
+  return (math_ops.unsorted_segment_sum(array_ops.gather(grad, op.inputs[2]),
+                                        op.inputs[1], input_rows), None, None)
+
+
+@ops.RegisterGradient("TFRA>SparseSegmentSumWithNumSegments")
+def _TfraSparseSegmentSumWithNumSegmentsGrad(op, grad):
+  """Gradient for TFRA>SparseSegmentSumWithNumSegments."""
+  input_rows = array_ops.shape(op.inputs[0])[0]
+  return (math_ops.unsorted_segment_sum(array_ops.gather(grad, op.inputs[2]),
+                                        op.inputs[1],
+                                        input_rows), None, None, None)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/math_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/math_ops.py
@@ -1,0 +1,138 @@
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""math operations."""
+# pylint: disable=g-bad-name
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import functools
+import tensorflow as tf
+
+from tensorflow.python.eager import context
+from tensorflow.python.framework import config
+from tensorflow.python.framework import errors
+from tensorflow.python.framework import ops
+from tensorflow.python.platform import tf_logging
+from tensorflow.python.training.saver import BaseSaverBuilder
+
+from tensorflow_recommenders_addons.utils.resource_loader import LazySO
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops import math_grad
+
+segment_reduction_ops = LazySO(
+    "dynamic_embedding/core/_segment_reduction_ops.so").ops
+
+
+def sparse_segment_sum(data,
+                       indices,
+                       segment_ids,
+                       name=None,
+                       num_segments=None):
+  """
+  Computes the sum along sparse segments of a tensor. It do same things
+  as `tf.sparse.segment_sum`. Here we provide GPU impl.
+
+  Go [tf api](https://www.tensorflow.org/api_docs/python/tf/sparse/segment_sum)
+  for more details.
+
+  Args:
+    data: A `Tensor` with data that will be assembled in the output.
+    indices: A 1-D `Tensor` with indices into `data`. Has same rank as
+      `segment_ids`.
+    segment_ids: A 1-D `Tensor` with indices into the output `Tensor`. Values
+      should be sorted and can be repeated.
+    name: A name for the operation (optional).
+    num_segments: An optional int32 scalar. Indicates the size of the output
+      `Tensor`.
+
+  Returns:
+    A `tensor` of the shape as data, except for dimension 0 which
+    has size `k`, the number of segments specified via `num_segments` or
+    inferred for the last element in `segments_ids`.
+  """
+  gpu_devices = config.list_physical_devices('GPU')
+  if gpu_devices:
+    if context.executing_eagerly():
+      try:
+        return _sparse_segment_sum_gpu(data,
+                                       indices,
+                                       segment_ids,
+                                       name=name,
+                                       num_segments=num_segments)
+      except errors.NotFoundError:
+        tf_logging.warn('`tfra.dynamic_embedding.sparse_segment_sum` is not'
+                        ' found. Use tf.sparse.segment_sum instead.')
+        return tf.sparse.segment_sum(data,
+                                     indices,
+                                     segment_ids,
+                                     name=name,
+                                     num_segments=num_segments)
+
+    else:
+      predef = _sparse_segment_sum_gpu(data,
+                                       indices,
+                                       segment_ids,
+                                       name=name,
+                                       num_segments=num_segments)
+      use_origin = True
+      if predef.device == '':
+        tf_logging.warn(
+            'Haven\'t specify devices while GPU devices are'
+            'available: {}, use CPU by default.'.format(gpu_devices))
+      else:
+        device_type = predef.device.split(':')[-2][-3:].lower()
+        if device_type == 'gpu':
+          use_origin = False
+
+      if use_origin:
+        return tf.sparse.segment_sum(data,
+                                     indices,
+                                     segment_ids,
+                                     name=name,
+                                     num_segments=num_segments)
+      return predef
+
+  else:
+    return tf.sparse.segment_sum(data,
+                                 indices,
+                                 segment_ids,
+                                 name=name,
+                                 num_segments=num_segments)
+
+
+def _sparse_segment_sum_gpu(data,
+                            indices,
+                            segment_ids,
+                            name=None,
+                            num_segments=None):
+  if not hasattr(segment_reduction_ops, 'tfra_sparse_segment_sum'):
+    tf_logging.warn('`tfra.dynamic_embedding.sparse_segment_sum` is not'
+                    ' found. Use tf.sparse.segment_sum instead.')
+    return tf.sparse.segment_sum(data,
+                                 indices,
+                                 segment_ids,
+                                 name=name,
+                                 num_segments=num_segments)
+
+  if num_segments is not None:
+    return segment_reduction_ops.tfra_sparse_segment_sum_with_num_segments(
+        data=data,
+        indices=indices,
+        segment_ids=segment_ids,
+        name=name,
+        num_segments=num_segments)
+  else:
+    return segment_reduction_ops.tfra_sparse_segment_sum(
+        data=data, indices=indices, segment_ids=segment_ids, name=name)

--- a/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
+++ b/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
@@ -1,5 +1,14 @@
-load("@local_config_tf//:build_defs.bzl", "D_GLIBCXX_USE_CXX11_ABI")
-load("@local_config_cuda//cuda:build_defs.bzl", "if_cuda", "if_cuda_is_configured")
+load(                                                                
+    "@local_config_tf//:build_defs.bzl",                             
+    "D_GLIBCXX_USE_CXX11_ABI",                                       
+    "DTF_MAJOR_VERSION",                                             
+    "DTF_MINOR_VERSION",                                             
+    "DTF_PATCH_VERSION")                                             
+load(                                                                
+    "@local_config_cuda//cuda:build_defs.bzl",                       
+    "if_cuda",                                                       
+    "if_cuda_is_configured",                                         
+)
 
 def custom_op_library(
         name,
@@ -51,7 +60,14 @@ def custom_op_library(
             "/DNOGDI",
             "/UTF_COMPILE_LIBRARY",
         ],
-        "//conditions:default": ["-pthread", "-std=c++11", D_GLIBCXX_USE_CXX11_ABI],
+        "//conditions:default": [
+            "-pthread",
+            "-std=c++14",
+            D_GLIBCXX_USE_CXX11_ABI,
+            DTF_MAJOR_VERSION,
+            DTF_MINOR_VERSION,
+            DTF_PATCH_VERSION,
+        ],
     })
 
     native.cc_binary(

--- a/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
+++ b/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
@@ -1,13 +1,14 @@
-load(                                                                
-    "@local_config_tf//:build_defs.bzl",                             
-    "D_GLIBCXX_USE_CXX11_ABI",                                       
-    "DTF_MAJOR_VERSION",                                             
-    "DTF_MINOR_VERSION",                                             
-    "DTF_PATCH_VERSION")                                             
-load(                                                                
-    "@local_config_cuda//cuda:build_defs.bzl",                       
-    "if_cuda",                                                       
-    "if_cuda_is_configured",                                         
+load(
+    "@local_config_tf//:build_defs.bzl",
+    "DTF_MAJOR_VERSION",
+    "DTF_MINOR_VERSION",
+    "DTF_PATCH_VERSION",
+    "D_GLIBCXX_USE_CXX11_ABI",
+)
+load(
+    "@local_config_cuda//cuda:build_defs.bzl",
+    "if_cuda",
+    "if_cuda_is_configured",
 )
 
 def custom_op_library(

--- a/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
+++ b/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
@@ -1,8 +1,6 @@
 load(
     "@local_config_tf//:build_defs.bzl",
-    "DTF_MAJOR_VERSION",
-    "DTF_MINOR_VERSION",
-    "DTF_PATCH_VERSION",
+    "DTF_VERSION",
     "D_GLIBCXX_USE_CXX11_ABI",
 )
 load(
@@ -65,9 +63,7 @@ def custom_op_library(
             "-pthread",
             "-std=c++14",
             D_GLIBCXX_USE_CXX11_ABI,
-            DTF_MAJOR_VERSION,
-            DTF_MINOR_VERSION,
-            DTF_PATCH_VERSION,
+            DTF_VERSION,
         ],
     })
 

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -76,7 +76,7 @@ COPY ./tools/install_deps/buildifier.sh ./
 RUN sh buildifier.sh
 
 COPY ./ /recommenders-addons
-RUN buildifier -mode=check -r /recommenders-addons
+RUN buildifier -mode=diff -r /recommenders-addons
 RUN touch /ok.txt
 
 # -------------------------------

--- a/tools/pre_commit_format.py
+++ b/tools/pre_commit_format.py
@@ -18,7 +18,7 @@ def _run_format():
     files_changed = True
 
   try:
-    check_bash_call("buildifier -mode=check -r .")
+    check_bash_call("buildifier -mode=diff -r .")
   except CalledProcessError:
     check_bash_call("buildifier -r .")
     files_changed = True


### PR DESCRIPTION
`SparseSegmentSum` and `SparseSegmentSumWithNumSegments` are two important opeartions in sparse training and inference. Currently, there are no GPU impl in Tensorflow for them.

This PR provide GPU version of `SparseSegmentSum` and `SparseSegmentSumWithNumSegments`