### PR TITLE
fix movielens spelling mistake

### DIFF
--- a/demo/movielens-1m-ps/movielens-1m-ps.py
+++ b/demo/movielens-1m-ps/movielens-1m-ps.py
@@ -41,7 +41,7 @@ class Trainer():
     split_start = split_size * self.worker_id
     split = 'train[{}%:{}%]'.format(split_start, split_start + split_size - 1)
     print("dataset split, worker{}: {}".format(self.worker_id, split))
-    ratings = tfds.load("movielens/1m-ratings", split=split)
+    ratings = tfds.load("movie_lens/1m-ratings", split=split)
     ratings = ratings.map(
         lambda x: {
             "movie_id": tf.strings.to_number(x["movie_id"], tf.int64),


### PR DESCRIPTION
# Description
demo run error

Brief Description of the PR:

Fixes # (issue)
fix spelling mistake movielens->movie_lens
## Type of change

- [*] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
