### PR TITLE
[feat] bpv2 (update de by adding delta instead of setting)

### DIFF
--- a/demo/bpv2/README.md
+++ b/demo/bpv2/README.md
@@ -1,0 +1,11 @@
+# A simple training demo for `bp_v2`
+
+## start train:
+```
+sh train.sh
+```
+
+## stop train:
+```
+sh stop.sh
+```

--- a/demo/bpv2/bpv2.py
+++ b/demo/bpv2/bpv2.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8 -*-
+
+import os, json
+import numpy as np
+import tensorflow as tf
+import tensorflow_recommenders_addons as tfra
+
+from absl import app
+
+batch_size = 128
+vocab_size = 10000
+embed_size = 64
+
+
+def make_word_index():
+  word_index = tf.keras.datasets.imdb.get_word_index()
+  word_index = {k: (v + 3) for k, v in word_index.items()}
+  word_index["<PAD>"] = 0
+  word_index["<START>"] = 1
+  word_index["<UNK>"] = 2  # unknown
+  word_index["<UNUSED>"] = 3
+  reverse_word_index = dict([
+      (value, key) for (key, value) in word_index.items()
+  ])
+  return word_index, reverse_word_index
+
+
+def decode_review(text):
+  return ' '.join([reverse_word_index.get(i, '?') for i in text])
+
+
+word_index, reverse_word_index = make_word_index()
+
+
+def get_data():
+  (train_data, train_labels), (test_data,
+                               test_labels) = tf.keras.datasets.imdb.load_data(
+                                   num_words=10000, path='imdb-0')
+  train_data = tf.keras.preprocessing.sequence.pad_sequences(
+      train_data, value=word_index["<PAD>"], padding='post', maxlen=256)
+  test_data = tf.keras.preprocessing.sequence.pad_sequences(
+      test_data, value=word_index["<PAD>"], padding='post', maxlen=256)
+  x_val = train_data[:1024]
+  x_train = train_data[:1024]
+  y_val = train_labels[:1024]
+  y_train = train_labels[:1024]
+  return x_train, y_train, x_val, y_val
+
+
+x_train, y_train, x_val, y_val = get_data()
+
+
+def input_fn_train():
+  dataset = tf.data.Dataset.from_tensor_slices(({'x': x_train}, y_train))
+  dataset = dataset.shuffle(1000).repeat().batch(batch_size)
+  return dataset
+
+
+def input_fn_val():
+  dataset = tf.data.Dataset.from_tensor_slices(({'x': x_val}, y_val))
+  dataset = dataset.shuffle(1000).repeat().batch(batch_size)
+  return dataset
+
+
+def model_fn(features, labels, mode):
+  x = features['x']
+  x = tf.reshape(x, [-1])
+  uniqx, uniqxidx = tf.unique(x)
+  w = tfra.dynamic_embedding.get_variable(
+      name='w',
+      devices=["/job:ps/replica:0/task:0/CPU:0"],
+      initializer=tf.random_normal_initializer(0, 0.5),
+      dim=embed_size,
+      bp_v2=True,  # this is the only thing you need to do to enable bpv2
+      key_dtype=tf.int32)
+  uniqe = tfra.dynamic_embedding.embedding_lookup(params=w, ids=uniqx, name='a')
+  e = tf.gather(uniqe, uniqxidx)
+  e = tf.reshape(e, [-1, 256, embed_size])
+
+  embmean = tf.reduce_mean(e, axis=1)
+  fc1 = tf.layers.dense(embmean, 16, activation=tf.nn.relu)
+  logits = tf.layers.dense(fc1, 2, activation=None)
+  predictions = {
+      "classes": tf.argmax(input=logits, axis=1),
+      "probabilities": tf.nn.softmax(logits, name="softmax_tensor"),
+  }
+
+  y = tf.one_hot(tf.cast(labels, tf.int32), 2, 1, 0)
+  loss = tf.losses.softmax_cross_entropy(y, logits)
+
+  if mode == tf.estimator.ModeKeys.TRAIN:
+    opt = tf.compat.v1.train.AdamOptimizer(0.01)
+    opt = tfra.dynamic_embedding.DynamicEmbeddingOptimizer(opt)
+    global_step = tf.compat.v1.train.get_or_create_global_step()
+    train_op = opt.minimize(loss, global_step=global_step)
+    return tf.estimator.EstimatorSpec(mode=mode, loss=loss, train_op=train_op)
+  else:
+    eval_metric_ops = {
+        "accuracy":
+            tf.metrics.accuracy(labels=labels,
+                                predictions=predictions["classes"])
+    }
+    return tf.estimator.EstimatorSpec(mode=mode,
+                                      loss=loss,
+                                      eval_metric_ops=eval_metric_ops)
+
+
+def main(argv):
+  del argv
+  tf_config = json.loads(os.environ.get('TF_CONFIG') or '{}')
+
+  config = tf.estimator.RunConfig(save_checkpoints_steps=None,
+                                  save_checkpoints_secs=tf.int64.max,
+                                  model_dir=None,
+                                  log_step_count_steps=1)
+  classifier = tf.estimator.Estimator(model_fn=model_fn, config=config)
+  tf.estimator.train_and_evaluate(
+      classifier,
+      train_spec=tf.estimator.TrainSpec(input_fn=input_fn_train,
+                                        max_steps=3000),
+      eval_spec=tf.estimator.EvalSpec(input_fn=input_fn_val, steps=1000))
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/demo/bpv2/stop.sh
+++ b/demo/bpv2/stop.sh
@@ -1,0 +1,2 @@
+ps -ef|grep "bpv2.py"|grep -v grep|awk '{print $2}'| xargs kill -9
+sleep 1

--- a/demo/bpv2/train.sh
+++ b/demo/bpv2/train.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+sh stop.sh
+
+export TF_CONFIG='{"cluster": {"worker": ["localhost:2222"], "ps": ["localhost:2223"], "chief": ["localhost:2224"]}, "task": {"type": "ps", "index": 0}}'
+python bpv2.py &
+
+sleep 1
+export TF_CONFIG='{"cluster": {"worker": ["localhost:2222"], "ps": ["localhost:2223"], "chief": ["localhost:2224"]}, "task": {"type": "chief", "index": 0}}'
+python bpv2.py &
+
+sleep 1
+export TF_CONFIG='{"cluster": {"worker": ["localhost:2222"], "ps": ["localhost:2223"], "chief": ["localhost:2224"]}, "task": {"type": "worker", "index": 0}}'
+python bpv2.py &

--- a/docs/api_docs/tfra/dynamic_embedding/Variable.md
+++ b/docs/api_docs/tfra/dynamic_embedding/Variable.md
@@ -58,7 +58,8 @@ __init__(
     trainable=True,
     checkpoint=True,
     init_size=0,
-    restrict_policy=None
+    restrict_policy=None,
+    bp_v2=False,
 )
 ```
 
@@ -105,6 +106,9 @@ def default_partition_fn(keys, shard_num):
   size of variable. If in training program, the variable is updated by
   optimizer, then the sparse slot variables in optimizer are also be
   restricted.
+* <b>`bp_v2`</b>:update parameters by *updating* instead of *setting*, which solves
+  the race condition problem among workers during backpropagation in large-scale
+  distributed asynchronous training.
 
 
 #### Returns:

--- a/docs/api_docs/tfra/dynamic_embedding/get_variable.md
+++ b/docs/api_docs/tfra/dynamic_embedding/get_variable.md
@@ -37,7 +37,8 @@ tfra.dynamic_embedding.get_variable(
     trainable=True,
     checkpoint=True,
     init_size=0,
-    restrict_policy=None
+    restrict_policy=None,
+    bp_v2=False,
 )
 ```
 
@@ -80,6 +81,9 @@ def default_partition_fn(keys, shard_num):
   size of variable. If in training program, the variable is updated by
   optimizer, then the sparse slot variables in optimizer are also be
   restricted.
+* <b>`bp_v2`</b>:update parameters by *updating* instead of *setting*, which solves
+  the race condition problem among workers during backpropagation in large-scale
+  distributed asynchronous training.
 
 
 #### Returns:

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_optimizer_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_optimizer_test.py
@@ -102,7 +102,7 @@ default_config = config_pb2.ConfigProto(
 
 class CommonTrainableTestV1Base(object):
 
-  def common_minimize_trainable(self, base_opt, test_opt, name):
+  def common_minimize_trainable(self, base_opt, test_opt, name, bp_v2):
     raise NotImplementedError
 
   def device_check(self, de):
@@ -113,13 +113,19 @@ class CommonTrainableTestV1Base(object):
   def test_adadelta_minimize_trainable(self):
     base_opt = adadelta.AdadeltaOptimizer(1.0)
     test_opt = adadelta.AdadeltaOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="adadelta")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adadelta",
+                                   bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_adagrad_minimize_trainable(self):
     base_opt = adagrad.AdagradOptimizer(1.0)
     test_opt = adagrad.AdagradOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="adagrad")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adagrad",
+                                   bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_adagradda_minimize_trainable(self):
@@ -127,43 +133,55 @@ class CommonTrainableTestV1Base(object):
 
     base_opt = adagrad_da.AdagradDAOptimizer(1.0, base_gs)
     test_opt = adagrad_da.AdagradDAOptimizer(1.0, base_gs)
-    self.common_minimize_trainable(base_opt, test_opt, name="adagrad_da")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adagrad_da",
+                                   bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_ftrl_minimize_trainable(self):
     base_opt = ftrl.FtrlOptimizer(1.0)
     test_opt = ftrl.FtrlOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="ftrl")
+    self.common_minimize_trainable(base_opt, test_opt, name="ftrl", bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_proximal_adagrad_minimize_trainable(self):
     base_opt = proximal_adagrad.ProximalAdagradOptimizer(1.0)
     test_opt = proximal_adagrad.ProximalAdagradOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="proximal_adagrad")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="proximal_adagrad",
+                                   bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_proximalsgd_minimize_trainable(self):
     base_opt = pgd.ProximalGradientDescentOptimizer(1.0)
     test_opt = pgd.ProximalGradientDescentOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="proximal_sgd")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="proximal_sgd",
+                                   bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_momentum_minimize_trainable(self):
     base_opt = momentum.MomentumOptimizer(1.0, momentum=0.9)
     test_opt = momentum.MomentumOptimizer(1.0, momentum=0.9)
-    self.common_minimize_trainable(base_opt, test_opt, name="momentum")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="momentum",
+                                   bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_sgd_minimize_trainable(self):
     base_opt = gradient_descent.GradientDescentOptimizer(1.0)
     test_opt = gradient_descent.GradientDescentOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="sgd")
+    self.common_minimize_trainable(base_opt, test_opt, name="sgd", bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_adam_minimize_trainable(self):
     base_opt = adam.AdamOptimizer(1.0)
     test_opt = adam.AdamOptimizer(1.0)
-    self.common_minimize_trainable(base_opt, test_opt, name="adam")
+    self.common_minimize_trainable(base_opt, test_opt, name="adam", bp_v2=False)
 
   @test_util.deprecated_graph_mode_only
   def test_rmsprop_minimize_trainable(self):
@@ -172,7 +190,92 @@ class CommonTrainableTestV1Base(object):
       test_opt = rmsprop.RMSPropOptimizer(1.0, centered=centered_)
       self.common_minimize_trainable(base_opt,
                                      test_opt,
-                                     name="rmsprop" + str(centered_))
+                                     name="rmsprop" + str(centered_),
+                                     bp_v2=False)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adadelta_minimize_trainable_bpv2(self):
+    base_opt = adadelta.AdadeltaOptimizer(1.0)
+    test_opt = adadelta.AdadeltaOptimizer(1.0)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adadelta",
+                                   bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adagrad_minimize_trainable_bpv2(self):
+    base_opt = adagrad.AdagradOptimizer(1.0)
+    test_opt = adagrad.AdagradOptimizer(1.0)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adagrad",
+                                   bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adagradda_minimize_trainable_bpv2(self):
+    base_gs = training_util.create_global_step()
+
+    base_opt = adagrad_da.AdagradDAOptimizer(1.0, base_gs)
+    test_opt = adagrad_da.AdagradDAOptimizer(1.0, base_gs)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adagrad_da",
+                                   bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_ftrl_minimize_trainable_bpv2(self):
+    base_opt = ftrl.FtrlOptimizer(1.0)
+    test_opt = ftrl.FtrlOptimizer(1.0)
+    self.common_minimize_trainable(base_opt, test_opt, name="ftrl", bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_proximal_adagrad_minimize_trainable_bpv2(self):
+    base_opt = proximal_adagrad.ProximalAdagradOptimizer(1.0)
+    test_opt = proximal_adagrad.ProximalAdagradOptimizer(1.0)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="proximal_adagrad",
+                                   bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_proximalsgd_minimize_trainable_bpv2(self):
+    base_opt = pgd.ProximalGradientDescentOptimizer(1.0)
+    test_opt = pgd.ProximalGradientDescentOptimizer(1.0)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="proximal_sgd",
+                                   bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_momentum_minimize_trainable_bpv2(self):
+    base_opt = momentum.MomentumOptimizer(1.0, momentum=0.9)
+    test_opt = momentum.MomentumOptimizer(1.0, momentum=0.9)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="momentum",
+                                   bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_sgd_minimize_trainable_bpv2(self):
+    base_opt = gradient_descent.GradientDescentOptimizer(1.0)
+    test_opt = gradient_descent.GradientDescentOptimizer(1.0)
+    self.common_minimize_trainable(base_opt, test_opt, name="sgd", bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_adam_minimize_trainable_bpv2(self):
+    base_opt = adam.AdamOptimizer(1.0)
+    test_opt = adam.AdamOptimizer(1.0)
+    self.common_minimize_trainable(base_opt, test_opt, name="adam", bp_v2=True)
+
+  @test_util.deprecated_graph_mode_only
+  def test_rmsprop_minimize_trainable_bpv2(self):
+    for centered_ in [False, True]:
+      base_opt = rmsprop.RMSPropOptimizer(1.0, centered=centered_)
+      test_opt = rmsprop.RMSPropOptimizer(1.0, centered=centered_)
+      self.common_minimize_trainable(base_opt,
+                                     test_opt,
+                                     name="rmsprop" + str(centered_),
+                                     bp_v2=True)
 
 
 class CommonTrainableTestV2Base(object):
@@ -243,7 +346,7 @@ class CommonTrainableTestV2Base(object):
 
 class EmbeddingLookupTrainableV1Test(test.TestCase, CommonTrainableTestV1Base):
 
-  def common_minimize_trainable(self, base_opt, test_opt, name):
+  def common_minimize_trainable(self, base_opt, test_opt, name, bp_v2):
     de.enable_train_mode()
     base_opt = de.DynamicEmbeddingOptimizer(base_opt)
     test_opt = de.DynamicEmbeddingOptimizer(test_opt)
@@ -298,6 +401,7 @@ class EmbeddingLookupTrainableV1Test(test.TestCase, CommonTrainableTestV1Base):
             devices=_get_devices() * num_shards,
             initializer=1.0,
             dim=dim,
+            bp_v2=bp_v2,
         )
         self.device_check(embeddings)
         init_ids = constant_op.constant(raw_init_ids, dtype=k_dtype)
@@ -436,7 +540,7 @@ class EmbeddingLookupTrainableV2Test(test.TestCase, CommonTrainableTestV2Base):
 class EmbeddingLookupUniqueTrainableV1Test(test.TestCase,
                                            CommonTrainableTestV1Base):
 
-  def common_minimize_trainable(self, base_opt, test_opt, name):
+  def common_minimize_trainable(self, base_opt, test_opt, name, bp_v2):
     de.enable_train_mode()
     base_opt = de.DynamicEmbeddingOptimizer(base_opt)
     test_opt = de.DynamicEmbeddingOptimizer(test_opt)
@@ -632,7 +736,7 @@ class EmbeddingLookupUniqueTrainableV2Test(test.TestCase,
 class EmbeddingLookupSparseTrainableV1Test(test.TestCase,
                                            CommonTrainableTestV1Base):
 
-  def common_minimize_trainable(self, base_opt, test_opt, name):
+  def common_minimize_trainable(self, base_opt, test_opt, name, bp_v2):
     de.enable_train_mode()
     base_opt = de.DynamicEmbeddingOptimizer(base_opt)
     test_opt = de.DynamicEmbeddingOptimizer(test_opt)
@@ -889,7 +993,7 @@ class SafeEmbeddingLookupSparseTrainableV1Test(test.TestCase,
                                                CommonTrainableTestV1Base):
 
   @test_util.deprecated_graph_mode_only
-  def common_minimize_trainable(self, base_opt, test_opt, name):
+  def common_minimize_trainable(self, base_opt, test_opt, name, bp_v2):
     de.enable_train_mode()
     base_opt = de.DynamicEmbeddingOptimizer(base_opt)
     test_opt = de.DynamicEmbeddingOptimizer(test_opt)
@@ -1190,7 +1294,7 @@ class TrainDynamicEmbeddingInMonitoredTrainingSessionTest(test.TestCase):
 
         self.device_check(table)
 
-  def common_minimize_trainable(self, base_opt, test_opt, name):
+  def common_minimize_trainable(self, base_opt, test_opt, name, bp_v2):
     de.enable_train_mode()
     base_opt = de.DynamicEmbeddingOptimizer(base_opt)
     test_opt = de.DynamicEmbeddingOptimizer(test_opt)
@@ -1318,12 +1422,28 @@ class TrainDynamicEmbeddingInMonitoredTrainingSessionTest(test.TestCase):
   def test_adam_minimize_trainable(self):
     base_opt = adam.AdamOptimizer(0.1)
     test_opt = adam.AdamOptimizer(0.1)
-    self.common_minimize_trainable(base_opt, test_opt, name="adam")
+    self.common_minimize_trainable(base_opt, test_opt, name="adam", bp_v2=False)
 
   def test_adagrad_minimize_trainable(self):
     base_opt = adagrad.AdagradOptimizer(0.1)
     test_opt = adagrad.AdagradOptimizer(0.1)
-    self.common_minimize_trainable(base_opt, test_opt, name="adagrad")
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adagrad",
+                                   bp_v2=False)
+
+  def test_adam_minimize_trainable_bp_v2(self):
+    base_opt = adam.AdamOptimizer(0.1)
+    test_opt = adam.AdamOptimizer(0.1)
+    self.common_minimize_trainable(base_opt, test_opt, name="adam", bp_v2=True)
+
+  def test_adagrad_minimize_trainable_bp_v2(self):
+    base_opt = adagrad.AdagradOptimizer(0.1)
+    test_opt = adagrad.AdagradOptimizer(0.1)
+    self.common_minimize_trainable(base_opt,
+                                   test_opt,
+                                   name="adagrad",
+                                   bp_v2=True)
 
 
 @test_util.deprecated_graph_mode_only

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -95,7 +95,10 @@ def DynamicEmbeddingOptimizer(self):
             var.params.restrict_policy._track_optimizer_slots(_slots)
 
           with ops.control_dependencies([grad]):
-            _before = [var.read_value()] + [_s.read_value() for _s in _slots]
+            v0 = var.read_value(do_prefetch=not var.params.bp_v2)
+            s0 = [_s.read_value() for _s in _slots]
+            _before = [v0] + s0
+
           if isinstance(grad, ops.IndexedSlices):
             if var.constraint is not None:
               raise RuntimeError(
@@ -106,8 +109,9 @@ def DynamicEmbeddingOptimizer(self):
               _apply_op = self._resource_apply_sparse_duplicate_indices(
                   grad.values, var, grad.indices, **apply_kwargs)
             with ops.control_dependencies([_apply_op]):
-              _after = control_flow_ops.group([var.update_op()] +
-                                              [_s.update_op() for _s in _slots])
+              _after = control_flow_ops.group(
+                  [var.update_op(v0=v0)] +
+                  [_s.update_op(v0=s0[si]) for si, _s in enumerate(_slots)])
               return _after
 
           if "apply_state" in self._dense_apply_args:
@@ -119,8 +123,9 @@ def DynamicEmbeddingOptimizer(self):
               return var.assign(var.constraint(var))
           else:
             with ops.control_dependencies([update_op]):
-              _after = control_flow_ops.group([var.update_op()] +
-                                              [_s.update_op() for _s in _slots])
+              _after = control_flow_ops.group(
+                  [var.update_op(v0=v0)] +
+                  [_s.update_op(v0=s0[si]) for si, _s in enumerate(_slots)])
             return _after
 
     update_ops = []
@@ -300,6 +305,7 @@ def create_slots(primary, init, slot_name, op_name):
           init_size=params_var_.init_size,
           trainable=False,
           checkpoint=params_var_.checkpoint,
+          bp_v2=params_var_.bp_v2,
       )
 
     scope_store._vars[full_name] = slot_variable_


### PR DESCRIPTION
# Description

Brief Description of the PR:

DE of tfra used to update embeddings / slots of embeddings by *setting* values, which introduces race condition problem among workers.

This PR solves this problem by updating MHTs of DE using the `CuckooHashTable.Accum`.

## Type of change

- [ ] Bug fix
- [x] New Tutorial
- [x] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
  - [x] By running yapf
  - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:

*  see `./demo/bpv2/*`
*  see `./tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_optimizer_test.py`

