### PR TITLE
Fix bug: incompatible jobs with explicit placement.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
@@ -481,8 +481,8 @@ class EmbeddingLookupTest(test.TestCase):
     self.assertAllEqual(p1.name, "test/p1")
     self.assertAllEqual(p2.name, "test/p2")
     self.assertAllEqual(p1, p1_reuse)
-    self.assertEqual(t1.name, "test/q/emb:0")
-    self.assertEqual(t2.name, "test_1/q/emb:0")
+    self.assertEqual(t1.name, "test/q/emb/emb:0")
+    self.assertEqual(t2.name, "test/q/emb/emb_1:0")
     self.assertAllEqual(p1._tables[0].name, "test_p1_mht_1of1")
     self.assertAllEqual(p1_reuse._tables[0].name, "test_p1_mht_1of1")
     self.assertAllEqual(p2._tables[0].name, "test_p2_mht_1of1")
@@ -528,8 +528,10 @@ class EmbeddingLookupTest(test.TestCase):
     self.assertAllEqual(p1.name, "test/p1")
     self.assertAllEqual(p2.name, "test/p2")
     self.assertAllEqual(p1, p1_reuse)
-    self.assertEqual(t1.name, "test/q/sp_emb/sp_emb/embedding_lookup:0")
-    self.assertEqual(t2.name, "test/q/sp_emb/sp_emb/embedding_lookup_1:0")
+    self.assertEqual(
+        t1.name, "test/q/sp_emb/embedding_lookup/sp_emb/embedding_lookup:0")
+    self.assertEqual(
+        t2.name, "test/q/sp_emb/embedding_lookup/sp_emb/embedding_lookup_1:0")
     self.assertAllEqual(p1._tables[0].name, "test_p1_mht_1of1")
     self.assertAllEqual(p1_reuse._tables[0].name, "test_p1_mht_1of1")
     self.assertAllEqual(p2._tables[0].name, "test_p2_mht_1of1")
@@ -577,11 +579,11 @@ class EmbeddingLookupTest(test.TestCase):
     self.assertAllEqual(p1, p1_reuse)
     self.assertEqual(
         t1.name,
-        "test/q/safe_sp_emb/embedding_lookup_sparse/safe_sp_emb/embedding_lookup_sparse/embedding_lookup:0",
+        "test/q/safe_sp_emb/embedding_lookup_sparse/embedding_lookup/safe_sp_emb/embedding_lookup_sparse/embedding_lookup:0",
     )
     self.assertEqual(
         t2.name,
-        "test/q/safe_sp_emb/embedding_lookup_sparse/safe_sp_emb/embedding_lookup_sparse/embedding_lookup_1:0",
+        "test/q/safe_sp_emb/embedding_lookup_sparse/embedding_lookup/safe_sp_emb/embedding_lookup_sparse/embedding_lookup_1:0",
     )
     self.assertAllEqual(p1._tables[0].name, "test_p1_mht_1of1")
     self.assertAllEqual(p1_reuse._tables[0].name, "test_p1_mht_1of1")

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
@@ -238,7 +238,7 @@ class CuckooHashTable(LookupInterface):
         (self.resource_handle, keys, self._default_value),
     ):
       keys = ops.convert_to_tensor(keys, dtype=self._key_dtype, name="keys")
-      with ops.colocate_with(self.resource_handle):
+      with ops.colocate_with(self.resource_handle, ignore_existing=True):
         if return_exists:
           values, exists = cuckoo_ops.tfra_cuckoo_hash_table_find_with_exists(
               self.resource_handle,
@@ -279,7 +279,7 @@ class CuckooHashTable(LookupInterface):
     ):
       keys = ops.convert_to_tensor(keys, self._key_dtype, name="keys")
       values = ops.convert_to_tensor(values, self._value_dtype, name="values")
-      with ops.colocate_with(self.resource_handle):
+      with ops.colocate_with(self.resource_handle, ignore_existing=True):
         # pylint: disable=protected-access
         op = cuckoo_ops.tfra_cuckoo_hash_table_insert(self.resource_handle,
                                                       keys, values)
@@ -314,7 +314,7 @@ class CuckooHashTable(LookupInterface):
                                                self._value_dtype,
                                                name="values_or_deltas")
       exists = ops.convert_to_tensor(exists, dtypes.bool, name="exists")
-      with ops.colocate_with(self.resource_handle):
+      with ops.colocate_with(self.resource_handle, ignore_existing=True):
         # pylint: disable=protected-access
         op = cuckoo_ops.tfra_cuckoo_hash_table_accum(self.resource_handle, keys,
                                                      values_or_deltas, exists)


### PR DESCRIPTION
# Description

Brief Description of the PR: In graph mode, when the device context is explicitly specified by `device` or `replica_device_setter`, the session may raise incompatible error if the devices cannot be merged. This PR fixed the case.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  [demo](https://github.com/tensorflow/recommenders-addons/tree/master/demo/movielens-1m-ps)
