### PR TITLE
[fix] Added more type and value check for Redis backend config file to prevent unconditional setting.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
@@ -96,6 +96,19 @@ class RedisWrapper<RedisInstance, K, V,
           std::make_shared<RedisInstance>(RedisInstance(conn_opts, pool_opts));
       redis_client->set("key test for connecting", "val test for connecting",
                         std::chrono::milliseconds(1));
+      auto info_cluster = redis_client->command("info", "cluster");
+      auto tmp_char = strtok(info_cluster->str, "\n");
+      tmp_char = strtok(NULL, "\n");
+      tmp_char = strtok(tmp_char, ":");
+      auto cluster_bool = strtok(NULL, ":");
+      if (strcmp(cluster_bool, "1\r") != 0) {
+        LOG(ERROR)
+            << "Now is cluster mode but try to connect Redis single node. "
+               "Please check redis_connection_mode in config file.";
+        throw std::invalid_argument(
+            "Can not connect to single node when in cluster mode, "
+            "redis_connection_mode should be 1 when connect to single node.");
+      }
       return redis_client;
     } catch (const std::exception &err) {
       LOG(ERROR) << "RedisHandler--error: " << err.what();

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -115,6 +115,19 @@ class RedisWrapper<
           RedisInstance(sentinel, redis_connection_params.redis_master_name,
                         Role::MASTER, conn_opts, pool_opts));
       redis_client->ping();
+      auto info_cluster = redis_client->command("info", "cluster");
+      auto tmp_char = strtok(info_cluster->str, "\n");
+      tmp_char = strtok(NULL, "\n");
+      tmp_char = strtok(tmp_char, ":");
+      auto cluster_bool = strtok(NULL, ":");
+      if (strcmp(cluster_bool, "0\r") != 0) {
+        LOG(ERROR)
+            << "Now is single mode but try to connect Redis cluster nodes. "
+               "Please check redis_connection_mode in config file.";
+        throw std::invalid_argument(
+            "Can not connect to cluster nodes when in single mode, "
+            "redis_connection_mode should be 0 when connect to cluster nodes.");
+      }
       return redis_client;
     } catch (const std::exception &err) {
       LOG(ERROR) << "RedisHandler--error: " << err.what();
@@ -154,6 +167,19 @@ class RedisWrapper<
       static auto redis_client =
           std::make_shared<RedisInstance>(RedisInstance(conn_opts, pool_opts));
       redis_client->ping();
+      auto info_cluster = redis_client->command("info", "cluster");
+      auto tmp_char = strtok(info_cluster->str, "\n");
+      tmp_char = strtok(NULL, "\n");
+      tmp_char = strtok(tmp_char, ":");
+      auto cluster_bool = strtok(NULL, ":");
+      if (strcmp(cluster_bool, "0\r") != 0) {
+        LOG(ERROR)
+            << "Now is single mode but try to connect Redis cluster nodes. "
+               "Please check redis_connection_mode in config file.";
+        throw std::invalid_argument(
+            "Can not connect to cluster nodes when in single mode, "
+            "redis_connection_mode should be 0 when connect to cluster nodes.");
+      }
       return redis_client;
     } catch (const std::exception &err) {
       LOG(ERROR) << "RedisHandler--error: " << err.what();

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
@@ -195,6 +195,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_connection_mode =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_connection_mode should be json_integer";
+      throw std::invalid_argument(
+          "redis_connection_mode should be json_integer");
     }
   }
 
@@ -204,6 +208,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
       redis_connection_params->redis_master_name =
           std::string(json_hangar_it->second->u.string.ptr,
                       json_hangar_it->second->u.string.length);
+    } else {
+      LOG(ERROR) << "redis_master_name should be json_string";
+      throw std::invalid_argument("redis_master_name should be json_string");
     }
   }
 
@@ -216,8 +223,16 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
         if (value_depth1->type == json_string) {
           redis_connection_params->redis_host_ip.push_back(std::string(
               value_depth1->u.string.ptr, value_depth1->u.string.length));
+        } else {
+          LOG(ERROR) << "redis_host_ip should be json_string array";
+          throw std::invalid_argument(
+              "redis_hash_tags_runtime should be json_string array");
         }
       }
+    } else {
+      LOG(ERROR) << "redis_hash_tags_runtime should be json_string array";
+      throw std::invalid_argument(
+          "redis_hash_tags_runtime should be json_string array");
     }
   }
 
@@ -230,8 +245,16 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
         if (value_depth1->type == json_integer) {
           redis_connection_params->redis_host_port.push_back(
               value_depth1->u.integer);
+        } else {
+          LOG(ERROR) << "redis_host_port should be json_integer array";
+          throw std::invalid_argument(
+              "redis_host_port should be json_integer array");
         }
       }
+    } else {
+      LOG(ERROR) << "redis_hash_tags_runtime should be json_string array";
+      throw std::invalid_argument(
+          "redis_hash_tags_runtime should be json_string array");
     }
   }
 
@@ -241,6 +264,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
       redis_connection_params->redis_user =
           std::string(json_hangar_it->second->u.string.ptr,
                       json_hangar_it->second->u.string.length);
+    } else {
+      LOG(ERROR) << "redis_user should be json_string";
+      throw std::invalid_argument("redis_user should be json_string");
     }
   }
 
@@ -250,6 +276,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
       redis_connection_params->redis_password =
           std::string(json_hangar_it->second->u.string.ptr,
                       json_hangar_it->second->u.string.length);
+    } else {
+      LOG(ERROR) << "redis_password should be json_string";
+      throw std::invalid_argument("redis_password should be json_string");
     }
   }
 
@@ -257,6 +286,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
   if (json_hangar_it != json_hangar.end()) {
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_db = json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_db should be json_integer";
+      throw std::invalid_argument("redis_db should be json_integer");
     }
   }
 
@@ -265,6 +297,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_boolean) {
       redis_connection_params->redis_connect_keep_alive =
           json_hangar_it->second->u.boolean;
+    } else {
+      LOG(ERROR) << "redis_connect_keep_alive should be json_integer";
+      throw std::invalid_argument(
+          "redis_connect_keep_alive should be json_integer");
     }
   }
 
@@ -273,6 +309,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_connect_timeout =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_connect_timeout should be json_integer";
+      throw std::invalid_argument(
+          "redis_connect_timeout should be json_integer");
     }
   }
 
@@ -281,6 +321,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_socket_timeout =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_socket_timeout should be json_integer";
+      throw std::invalid_argument(
+          "redis_socket_timeout should be json_integer");
     }
   }
 
@@ -289,6 +333,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_conn_pool_size =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_conn_pool_size should be json_integer";
+      throw std::invalid_argument(
+          "redis_conn_pool_size should be json_integer");
     }
   }
 
@@ -297,6 +345,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_wait_timeout =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_wait_timeout should be json_integer";
+      throw std::invalid_argument("redis_wait_timeout should be json_integer");
     }
   }
 
@@ -305,6 +356,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_connection_lifetime =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_connection_lifetime should be json_integer";
+      throw std::invalid_argument(
+          "redis_connection_lifetime should be json_integer");
     }
   }
 
@@ -313,6 +368,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_sentinel_connect_timeout =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_sentinel_connect_timeout should be json_integer";
+      throw std::invalid_argument(
+          "redis_sentinel_connect_timeout should be json_integer");
     }
   }
 
@@ -321,6 +380,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->redis_sentinel_socket_timeout =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "redis_sentinel_socket_timeout should be json_integer";
+      throw std::invalid_argument(
+          "redis_sentinel_socket_timeout should be json_integer");
     }
   }
 
@@ -331,7 +394,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
           round_next_power_two_bitlen(json_hangar_it->second->u.integer);
       redis_connection_params->storage_slice =
           1 << redis_connection_params->storage_slice_log2;
-      ;
+    } else {
+      LOG(ERROR) << "storage_slice should be json_integer";
+      throw std::invalid_argument("storage_slice should be json_integer");
     }
   }
 
@@ -340,7 +405,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->keys_sending_size =
           json_hangar_it->second->u.integer;
-      ;
+    } else {
+      LOG(ERROR) << "keys_sending_size should be json_integer";
+      throw std::invalid_argument("keys_sending_size should be json_integer");
     }
   }
 
@@ -349,6 +416,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_boolean) {
       redis_connection_params->using_md5_prefix_name =
           json_hangar_it->second->u.boolean;
+    } else {
+      LOG(ERROR) << "using_md5_prefix_name should be json_boolean";
+      throw std::invalid_argument(
+          "using_md5_prefix_name should be json_boolean");
     }
   }
 
@@ -358,6 +429,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
       redis_connection_params->model_tag_import =
           std::string(json_hangar_it->second->u.string.ptr,
                       json_hangar_it->second->u.string.length);
+    } else {
+      LOG(ERROR) << "model_tag_import should be json_string";
+      throw std::invalid_argument("model_tag_import should be json_string");
     }
   }
 
@@ -370,8 +444,16 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
         if (value_depth1->type == json_string) {
           redis_connection_params->redis_hash_tags_import.push_back(std::string(
               value_depth1->u.string.ptr, value_depth1->u.string.length));
+        } else {
+          LOG(ERROR) << "redis_hash_tags_import should be json_string array";
+          throw std::invalid_argument(
+              "redis_hash_tags_runtime should be json_string array");
         }
       }
+    } else {
+      LOG(ERROR) << "redis_hash_tags_runtime should be json_string array";
+      throw std::invalid_argument(
+          "redis_hash_tags_runtime should be json_string array");
     }
   }
 
@@ -381,6 +463,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
       redis_connection_params->model_tag_runtime =
           std::string(json_hangar_it->second->u.string.ptr,
                       json_hangar_it->second->u.string.length);
+    } else {
+      LOG(ERROR) << "model_tag_runtime should be json_string";
+      throw std::invalid_argument("model_tag_runtime should be json_string");
     }
   }
 
@@ -394,8 +479,16 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
           redis_connection_params->redis_hash_tags_runtime.push_back(
               std::string(value_depth1->u.string.ptr,
                           value_depth1->u.string.length));
+        } else {
+          LOG(ERROR) << "redis_hash_tags_runtime should be json_string array";
+          throw std::invalid_argument(
+              "redis_hash_tags_runtime should be json_string array");
         }
       }
+    } else {
+      LOG(ERROR) << "redis_hash_tags_runtime should be json_string array";
+      throw std::invalid_argument(
+          "redis_hash_tags_runtime should be json_string array");
     }
   }
 
@@ -404,7 +497,10 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->expire_model_tag_in_seconds =
           json_hangar_it->second->u.integer;
-      ;
+    } else {
+      LOG(ERROR) << "expire_model_tag_in_seconds should be json_integer";
+      throw std::invalid_argument(
+          "expire_model_tag_in_seconds should be json_integer");
     }
   }
 
@@ -413,6 +509,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
     if (json_hangar_it->second->type == json_integer) {
       redis_connection_params->table_store_mode =
           json_hangar_it->second->u.integer;
+    } else {
+      LOG(ERROR) << "table_store_mode should be json_integer";
+      throw std::invalid_argument("table_store_mode should be json_integer");
     }
   }
 
@@ -422,6 +521,9 @@ void ParseJsonConfig(const std::string *const redis_config_abs_dir,
       redis_connection_params->model_lib_abs_dir =
           std::string(json_hangar_it->second->u.string.ptr,
                       json_hangar_it->second->u.string.length);
+    } else {
+      LOG(ERROR) << "model_lib_abs_dir should be json_string";
+      throw std::invalid_argument("model_lib_abs_dir should be json_string");
     }
   }
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
@@ -436,8 +436,7 @@ class RedisTableOfTensors final : public LookupInterface {
                                         keys_prefix_name_slices_in_redis[i]));
       const V *pv_raw =
           reinterpret_cast<const V *>(values_temp.tensor_data().data());
-      std::cerr << keys_reply->elements << " " << values_reply->elements
-                << std::endl;
+
       try {
         if (values_reply != nullptr) {
           for (size_t i = 0; i < values_reply->elements; ++i) {


### PR DESCRIPTION
# Description

Brief Description of the PR:
Added more type and value check for Redis backend config file to prevent unconditional setting.

**Fixes**
For example, user may set redis_connection_mode as 1(it means connecting to single Redis node), but when ze set 
redis_host_ip as one of the Redis cluster nodes IP, the TFRA-Redis backend will be crash for sending wrong command to Redis service. And now I forbidden this activity and throw an std::invalid_argument error.
Also, when user set a wrong type in the TFRA-Redis json config file, it will throw an std::invalid_argument error.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Setting the TFRA-Redis backend json config file without following the instructions. For example:

```json
{
  "redis_connection_mode": "0",
  "redis_master_name": "master",
  "redis_host_ip": [
    "127.0.0.1"
  ],
  "redis_host_port": [
    26379
  ],
  "redis_user": "default",
  "redis_password": "",
  "redis_db": 0,
  "redis_connect_keep_alive": false,
  "redis_connect_timeout": 100000000,
  "redis_socket_timeout": 100000000,
  "redis_conn_pool_size": 100,
  "redis_wait_timeout": 100000000,
  "redis_connection_lifetime": 100,
  "redis_sentinel_connect_timeout": 100000000,
  "redis_sentinel_socket_timeout": 100000000,
  "storage_slice": 1,
  "keys_sending_size": 1024,
  "using_md5_prefix_name": false,
  "model_tag_import": "test",
  "redis_hash_tags_import": [],
  "model_tag_runtime": "test",
  "redis_hash_tags_runtime": [],
  "expire_model_tag_in_seconds": 604800,
  "table_store_mode": 0,
  "model_lib_abs_dir": "/tmp/"
}
```
