### PR TITLE
[fix]We don't need singleton in TensorFlow OpKernel

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
@@ -86,7 +86,7 @@ class RedisWrapper<RedisInstance, K, V,
     SetPublicConnParams(conn_opts, pool_opts, redis_connection_params);
 
     try {
-      static auto redis_client = std::make_shared<RedisInstance>(
+      auto redis_client = std::make_shared<RedisInstance>(
           RedisInstance(conn_opts, pool_opts, role));
       redis_client->set("key test for connecting", "val test for connecting",
                         std::chrono::milliseconds(1));
@@ -153,10 +153,7 @@ class RedisWrapper<RedisInstance, K, V,
   }
 
   static std::shared_ptr<RedisWrapper<RedisInstance, K, V>> get_instance() {
-    /* for the Meyer's Singleton mode.
-      When make Class constructor private, it will be not allow using
-      make_shared to init the Class. It' not safe, but having no choice. */
-    static std::shared_ptr<RedisWrapper<RedisInstance, K, V>> instance_ptr(
+    std::shared_ptr<RedisWrapper<RedisInstance, K, V>> instance_ptr(
         new RedisWrapper<RedisInstance, K, V>());
     return instance_ptr;
   }

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -101,7 +101,7 @@ class RedisWrapper<
     auto sentinel = std::make_shared<Sentinel>(sentinel_opts);
 
     try {
-      static auto redis_client = std::make_shared<RedisInstance>(
+      auto redis_client = std::make_shared<RedisInstance>(
           RedisInstance(sentinel, redis_connection_params.redis_master_name,
                         role, conn_opts, pool_opts));
       redis_client->ping();
@@ -135,7 +135,7 @@ class RedisWrapper<
     SetPublicConnParams(conn_opts, pool_opts, redis_connection_params);
 
     try {
-      static auto redis_client =
+      auto redis_client =
           std::make_shared<RedisInstance>(RedisInstance(conn_opts, pool_opts));
       redis_client->ping();
       if (RedisClusterEnabled(redis_client) == true) {
@@ -189,10 +189,7 @@ class RedisWrapper<
   }
 
   static std::shared_ptr<RedisWrapper<RedisInstance, K, V>> get_instance() {
-    /* for the Meyer's Singleton mode.
-      When make Class constructor private, it will be not allow using
-      make_shared to init the Class. It' not safe, but having no choice. */
-    static std::shared_ptr<RedisWrapper<RedisInstance, K, V>> instance_ptr(
+    std::shared_ptr<RedisWrapper<RedisInstance, K, V>> instance_ptr(
         new RedisWrapper<RedisInstance, K, V>());
     return instance_ptr;
   }


### PR DESCRIPTION
# Description

Enabling singleton mode for classes in OpKernel results in only one Redis being connected when creating multiple Variable objects and wanna connect to different Redis service.

Fixes #175 

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [x] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Creating two different kv_creator which set to different Redis service, and apply them to the training.
