### PR TITLE
[Fix]change 'KEYS' command in GetKeyBucketsAndOptimizerParamsWithName function to 'SCAN' command

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
@@ -25,6 +25,7 @@ limitations under the License.
 
 #include <cmath>
 #include <iostream>
+#include <sstream>
 
 #include "md5.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -366,6 +367,9 @@ class RedisVirtualWrapper {
       const std::string &keys_prefix_name, const bool only_get_buckets) = 0;
 
   virtual int CheckSlicesNum(const std::string &keys_prefix_name) = 0;
+
+  virtual std::vector<std::pair<unsigned, unsigned>> ClusterNodesSlots(
+      bool full_slots) = 0;
 
   virtual size_t TableSizeInBucket(
       const std::string &keys_prefix_name_slice) = 0;

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import fcntl
 import functools
 import json
 import os
@@ -195,17 +196,23 @@ class RedisTable(LookupInterface):
     if self.redis_config_file_create == True and self.redis_config_file_exist == False:
       with open(self._config.redis_config_abs_dir, 'w+',
                 encoding='utf-8') as f0:
+        fcntl.flock(f0, fcntl.LOCK_EX)
         f0.write(
             json.dumps(self.default_redis_params, indent=2, ensure_ascii=True))
+        fcntl.flock(f0, fcntl.LOCK_UN)
     else:
       with open(self._config.redis_config_abs_dir, 'r', encoding='utf-8') as f0:
+        fcntl.flock(f0, fcntl.LOCK_EX)
         params_load = json.load(f0)
+        fcntl.flock(f0, fcntl.LOCK_UN)
         self._redis_params = self.default_redis_params.copy()
         for k in self._redis_params.keys():
           if k in params_load:
             self._redis_params[k] = params_load[k]
       with open(self._config.redis_config_abs_dir, 'w', encoding='utf-8') as f1:
+        fcntl.flock(f1, fcntl.LOCK_EX)
         f1.write(json.dumps(self._redis_params, indent=2, ensure_ascii=True))
+        fcntl.flock(f1, fcntl.LOCK_UN)
 
     self._shared_name = None
     if context.executing_eagerly():


### PR DESCRIPTION
# Description

Command "KEYS" was used in the GetKeyBucketsAndOptimizerParamsWithName function by DE redis backend. But Command "KEYS" may cause lots of trouble, such as a serious service delay. Command "SCAN" should be a better choice. In fact, "KEYS" are banned in many companies' Redis services.

Fixes #179 

What's more, add the ability to set hashtags via Redis cluster servers slots.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [x] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

run it again.
