### PR TITLE
[fix]Fix misprocessing of "CLUSTER NODES" return

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
@@ -443,9 +443,9 @@ std::vector<std::string> BuildKeysPrefixNameSlices(
     LOG(INFO)
         << "Number of prefix redis_hash_tags is not equal to the prefix "
            "storage_slice. Now using the hash tags generated sequentially.";
-    const unsigned slot_num_in_redis = 16384 / storage_slice;
-    const unsigned slot_in_redis_rem = 16384 % storage_slice;
     if (cluster_slots.size() == 0) {
+      const unsigned slot_num_in_redis = 16384 / storage_slice;
+      const unsigned slot_in_redis_rem = 16384 % storage_slice;
       for (unsigned i = 0; i < storage_slice; ++i) {
         keys_prefix_name_slices.emplace_back(
             keys_prefix_name + '{' +
@@ -473,8 +473,10 @@ std::vector<std::string> BuildKeysPrefixNameSlices(
           }
         }
       } else {
-        LOG(WARNING) << "Nodes in Redis service is bigger than storage_slice "
-                        "set by user, it may cause data skew.";
+        if (cluster_slots.size() > storage_slice) {
+          LOG(WARNING) << "Nodes in Redis service is bigger than storage_slice "
+                          "set by user, it may cause data skew.";
+        }
         for (unsigned i = 0; i < storage_slice; ++i) {
           keys_prefix_name_slices.emplace_back(
               keys_prefix_name + '{' +


### PR DESCRIPTION
# Description

Fixed a serious bug where the "myself,master" field in the node information returned by the "CLUSTER NODES" command was not being processed correctly.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

