### PR TITLE
[feat] Add storage_slice_import parameter for easy rehashing table.

### DIFF
--- a/docs/api_docs/tfra/dynamic_embedding/RedisBackend.md
+++ b/docs/api_docs/tfra/dynamic_embedding/RedisBackend.md
@@ -48,6 +48,7 @@ Below is an example of a JSON file, along with comments on the corresponding pro
       "redis_sentinel_socket_timeout": 1000,  // milliseconds
 
       // Below there is user-defined parameters in this custom op, not Redis setting parameters
+      "storage_slice_import": 2, // If storage_slice_import is not equal to storage_slice, rehash will happen. Equaling -1 means same as storage_slice.
       "storage_slice": 2,  // For deciding bucket number, which usually is how many Redis instance may be used in the trainning.
       "keys_sending_size": 1024,  // Determines how many keys to send at a time for performance tuning
       "using_md5_prefix_name": False,  // 1=true, 0=false
@@ -55,7 +56,7 @@ Below is an example of a JSON file, along with comments on the corresponding pro
       "redis_hash_tags_import": ["{6379}","{26379}"], // Deciding hash tag for every bucket from last time, Note that the hash tag must be wrapped in curly braces {}.
       "model_tag_runtime": "test",  // model_tag_runtime for version and any other information for now.
       "redis_hash_tags_runtime": ["{3560}","{120}"], // Deciding hash tag for every bucket for now, Note that the hash tag must be wrapped in curly braces {}.
-      "expire_model_tag_in_seconds": 604800,  // To eliminate unwanted model versions in Redis to ensure sufficient storage space.
+      "expire_model_tag_in_seconds": 604800,  // To eliminate unwanted model versions in Redis to ensure sufficient storage space. It will not take effect if it is less than zero.
       "table_store_mode": 1,  // Saving and restoring table into ensor in TF savedmodel variable file, table_store_mode = 0; Saving and restoring table into redis rdb file in model_lib_abs_dir, table_store_mode = 1; Saving and restoring nothing, keeping data in redis servers, table_store_mode = 2.
       "model_lib_abs_dir": "/tmp/"  // if table_store_mode equals 1, then it will try to save or resoter table from model_lib_abs_dir which has been mounted in system
   }

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/README.md
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/README.md
@@ -48,6 +48,7 @@ Below is an example of a JSON file, along with comments on the corresponding pro
       "redis_sentinel_socket_timeout": 1000,  // milliseconds
 
       // Below there is user-defined parameters in this custom op, not Redis setting parameters
+      "storage_slice_import": 2, // If storage_slice_import is not equal to storage_slice, rehash will happen. Equaling -1 means same as storage_slice.
       "storage_slice": 2,  // For deciding bucket number, which usually is how many Redis instance may be used in the trainning.
       "keys_sending_size": 1024,  // Determines how many keys to send at a time for performance tuning
       "using_md5_prefix_name": False,  // 1=true, 0=false
@@ -55,7 +56,7 @@ Below is an example of a JSON file, along with comments on the corresponding pro
       "redis_hash_tags_import": ["{6379}","{26379}"], // Deciding hash tag for every bucket from last time, Note that the hash tag must be wrapped in curly braces {}.
       "model_tag_runtime": "test",  // model_tag_runtime for version and any other information for now.
       "redis_hash_tags_runtime": ["{3560}","{120}"], // Deciding hash tag for every bucket for now, Note that the hash tag must be wrapped in curly braces {}.
-      "expire_model_tag_in_seconds": 604800,  // To eliminate unwanted model versions in Redis to ensure sufficient storage space.
+      "expire_model_tag_in_seconds": 604800,  // To eliminate unwanted model versions in Redis to ensure sufficient storage space. It will not take effect if it is less than zero.
       "table_store_mode": 1,  // Saving and restoring table into ensor in TF savedmodel variable file, table_store_mode = 0; Saving and restoring table into redis rdb file in model_lib_abs_dir, table_store_mode = 1; Saving and restoring nothing, keeping data in redis servers, table_store_mode = 2.
       "model_lib_abs_dir": "/tmp/"  // if table_store_mode equals 1, then it will try to save or resoter table from model_lib_abs_dir which has been mounted in system
   }

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -210,11 +210,11 @@ class RedisWrapper<
         redis_connection_params.storage_slice);
     while (true) {
       if (only_get_buckets) {
-        redis_command =
-            "SCAN " + std::to_string(cursor) + " MATCH {[0123456789]*}";
+        redis_command = "SCAN " + std::to_string(cursor) + " MATCH " +
+                        keys_prefix_name + "{[0123456789]*}";
       } else {
-        redis_command =
-            "SCAN " + std::to_string(cursor) + " MATCH *{[0123456789]*}";
+        redis_command = "SCAN " + std::to_string(cursor) + " MATCH " +
+                        keys_prefix_name + "*{[0123456789]*}";
       }
       try {
         reply_server = redis_conn_read->command(cmd, redis_command.data());
@@ -229,7 +229,7 @@ class RedisWrapper<
       }
       if (reply_server->element[1]->type == REDIS_REPLY_ARRAY) {
         set_reply = reply_server->element[1];
-        for (size_t i = 1; i < set_reply->elements; ++i) {
+        for (size_t i = 0; i < set_reply->elements; ++i) {
           keys_prefix_name_slices_in_redis.emplace_back(std::string(
               set_reply->element[i]->str, set_reply->element[i]->len));
         }
@@ -405,28 +405,29 @@ class RedisWrapper<
 
   virtual Status SetExpireBuckets(
       const std::string &keys_prefix_name) override {
-    // std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter> reply;
-    const std::string expire_command("EXPIRE ");
-    std::string redis_command;
-    auto cmd = [](::sw::redis::Connection &connection, const char *str) {
-      connection.send(str);
-    };
-    auto &&bucket_names =
-        GetKeyBucketsAndOptimizerParamsWithName(keys_prefix_name, false);
-    for (auto bucket_name : bucket_names) {
-      redis_command.clear();
-      redis_command =
-          expire_command + bucket_name + ' ' +
-          std::to_string(redis_connection_params.expire_model_tag_in_seconds);
-      try {
-        /*reply=*/redis_conn_write->command(cmd, redis_command.data());
-      } catch (const std::exception &err) {
-        LOG(ERROR) << "RedisHandler error in SetExpireBuckets for "
-                   << bucket_name << " -- " << err.what();
-        return errors::Unknown(err.what());
+    if (redis_connection_params.expire_model_tag_in_seconds >= 0) {
+      // std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter> reply;
+      const std::string expire_command("EXPIRE ");
+      std::string redis_command;
+      auto cmd = [](::sw::redis::Connection &connection, const char *str) {
+        connection.send(str);
+      };
+      auto &&bucket_names =
+          GetKeyBucketsAndOptimizerParamsWithName(keys_prefix_name, false);
+      for (auto bucket_name : bucket_names) {
+        redis_command.clear();
+        redis_command =
+            expire_command + bucket_name + ' ' +
+            std::to_string(redis_connection_params.expire_model_tag_in_seconds);
+        try {
+          /*reply=*/redis_conn_write->command(cmd, redis_command.data());
+        } catch (const std::exception &err) {
+          LOG(ERROR) << "RedisHandler error in SetExpireBuckets for "
+                     << bucket_name << " -- " << err.what();
+          return errors::Unknown(err.what());
+        }
       }
     }
-
     return Status::OK();
   }
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
@@ -153,13 +153,14 @@ struct Redis_Connection_Params {
   //
   // Below there is user-defined parameters in this custom op, not Redis
   // setting parameters
+  int storage_slice_import = -1;
   unsigned storage_slice =
-      1;  // For deciding bucket number, which usually is how many Redis
-          // instance may be used in the trainning.
-  unsigned storage_slice_log2 = 0;  // For fast calculation.
-  unsigned expire_model_tag_in_seconds =
+      1;  // For deciding bucket number, which usually is how
+          // many Redis instance may be used in the trainning.
+  int expire_model_tag_in_seconds =
       604800;  // To eliminate unwanted model versions in Redis to ensure
-               // sufficient storage space.
+               // sufficient storage space. It will not take effect if it is
+               // less than zero.
   unsigned long long keys_sending_size =
       1024;  // Determines how many keys to send at a time
              // for performance tuning
@@ -202,12 +203,10 @@ struct Redis_Connection_Params {
         x.redis_sentinel_connect_timeout;  // milliseconds
     redis_sentinel_socket_timeout =
         x.redis_sentinel_socket_timeout;  // milliseconds
-    storage_slice_log2 =
-        round_next_power_two_bitlen(x.storage_slice);  // beter for modding.
+    storage_slice_import =
+        x.storage_slice_import >= 0 ? x.storage_slice_import : x.storage_slice;
     storage_slice = x.storage_slice;
-    expire_model_tag_in_seconds = x.expire_model_tag_in_seconds > 0
-                                      ? x.expire_model_tag_in_seconds
-                                      : 2626560;
+    expire_model_tag_in_seconds = x.expire_model_tag_in_seconds;
     model_tag_import = x.model_tag_import;
     redis_hash_tags_import.assign(x.redis_hash_tags_import.begin(),
                                   x.redis_hash_tags_import.end());

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
@@ -325,19 +325,14 @@ Status ParseJsonConfig(const std::string *const redis_config_abs_dir,
 
   ReadOneJsonToParams(redis_sentinel_socket_timeout, integer);
 
-  json_hangar_it = json_hangar.find("storage_slice");
-  if (json_hangar_it != json_hangar.end()) {
-    if (json_hangar_it->second->type == json_integer) {
-      redis_connection_params->storage_slice_log2 =
-          round_next_power_two_bitlen(json_hangar_it->second->u.integer);
-      redis_connection_params->storage_slice =
-          json_hangar_it->second->u.integer;
-    } else {
-      LOG(ERROR) << "storage_slice should be json_integer";
-      return Status(error::INVALID_ARGUMENT,
-                    "storage_slice should be json_integer");
-    }
-  }
+  ReadOneJsonToParams(storage_slice_import, integer);
+
+  ReadOneJsonToParams(storage_slice, integer);
+
+  redis_connection_params->storage_slice_import =
+      redis_connection_params->storage_slice_import > 0
+          ? redis_connection_params->storage_slice_import
+          : redis_connection_params->storage_slice;
 
   ReadOneJsonToParams(keys_sending_size, integer);
 
@@ -489,7 +484,8 @@ void CreateKeysPrefixNameHandle(
       redis_connection_params->model_tag_import,
       redis_connection_params->using_md5_prefix_name, embedding_name);
   keys_prefix_name_slices_import = BuildKeysPrefixNameSlices(
-      cluster_slots, redis_connection_params->storage_slice,
+      cluster_slots,
+      static_cast<unsigned>(redis_connection_params->storage_slice_import),
       redis_connection_params->redis_hash_tags_import, keys_prefix_name_import);
 }
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_creator.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_creator.py
@@ -109,6 +109,7 @@ class RedisTableConfig(object):
         "redis_connection_lifetime": 100,
         "redis_sentinel_connect_timeout": 1000,
         "redis_sentinel_socket_timeout": 1000,
+        "storage_slice_import": 1,
         "storage_slice": 1,
         "keys_sending_size": 1024,
         "using_md5_prefix_name": False,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
@@ -80,6 +80,8 @@ class RedisTable(LookupInterface):
       "redis_sentinel_connect_timeout": 1000,  # milliseconds
       "redis_sentinel_socket_timeout": 1000,  # milliseconds
       # Below there is user-defined parameters in this custom op, not Redis setting parameters
+      "storage_slice_import":
+          -1,  # If storage_slice_import is not equal to storage_slice, rehash will happen. Equaling -1 means same as storage_slice.
       "storage_slice":
           1,  # For deciding bucket number, which usually is how many Redis instance may be used in the trainning.
       "keys_sending_size":
@@ -93,8 +95,9 @@ class RedisTable(LookupInterface):
           "test",  #  model_tag_runtime for version and any other information for now.
       "redis_hash_tags_runtime": [
       ],  # Deciding hash tag for every bucket for now, Note that the hash tag must be wrapped in curly braces {}.
-      "expire_model_tag_in_seconds":
-          604800,  # To eliminate unwanted model versions in Redis to ensure sufficient storage space.
+      "expire_model_tag_in_seconds": 604800,
+      # To eliminate unwanted model versions in Redis to ensure sufficient storage space.
+      # It will not take effect if it is less than zero.
       "table_store_mode": 1,
       # Saving and restoring table into ensor in TF savedmodel variable file, table_store_mode = 0;
       # Saving and restoring table into redis rdb file in model_lib_abs_dir, table_store_mode = 1;


### PR DESCRIPTION
# Description

Add storage_slice_import parameter for easy rehashing table.

Also sorting cluster_slots after get it.

Also allow not to set expire to buckets

Fix many bug when rehash(rebuckets), but there are still lots of bugs.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [x] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

set storage_slice_import in redis backend config file.
