### PR TITLE
Add ARM64 support for Redis backend.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include <inttypes.h>
-#include <nmmintrin.h>
 #include <sw/redis++/connection.h>
 #include <sw/redis++/connection_pool.h>
 #include <sw/redis++/redis++.h>


### PR DESCRIPTION
# Description

Add ARM64 support for Redis backend.

Also fix RedisClusterEnabled function to fit pika.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Build in arm env.
