### PR TITLE
[fix] Updated rules_foreign_cc from 0.0.9 to 0.6.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,15 +7,15 @@ load("//build_deps/toolchains/gpu:cuda_configure.bzl", "cuda_configure")
 
 http_archive(
     name = "rules_foreign_cc",
-    sha256 = "9f96cae32dca0578960468a5a9f66e1ddb8cba8cc210e3e8198f70a20dba45d1",
-    strip_prefix = "rules_foreign_cc-0.0.9",
-    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/refs/tags/0.0.9.zip",
+    sha256 = "69023642d5781c68911beda769f91fcbc8ca48711db935a75da7f6536b65047f",
+    strip_prefix = "rules_foreign_cc-0.6.0",
+    url = "https://github.com/bazelbuild/rules_foreign_cc/archive/0.6.0.tar.gz",
 )
 
-load("@rules_foreign_cc//:workspace_definitions.bzl", "rules_foreign_cc_dependencies")
+load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
 
 # This sets up some common toolchains for building targets. For more details, please see
-# https://bazelbuild.github.io/rules_foreign_cc/0.3.0/flatten.html#rules_foreign_cc_dependencies
+# https://bazelbuild.github.io/rules_foreign_cc/0.6.0/flatten.html#rules_foreign_cc_dependencies
 rules_foreign_cc_dependencies(register_default_tools = True)
 
 http_archive(

--- a/build_deps/toolchains/redis/hiredis.BUILD
+++ b/build_deps/toolchains/redis/hiredis.BUILD
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 load(
     "@local_config_tf//:build_defs.bzl",
     "D_GLIBCXX_USE_CXX11_ABI",
@@ -16,13 +16,12 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cmake_external(
+cmake(
     name = "hiredis",
-    cmake_options = [
+    generate_args = [
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_CXX_FLAGS="+D_GLIBCXX_USE_CXX11_ABI,
     ],
     lib_source = "@hiredis//:all_srcs",
-    static_libraries = ["libhiredis_static.a"],
+    out_static_libs = ["libhiredis_static.a"],
 )
-

--- a/build_deps/toolchains/redis/redis-plus-plus.BUILD
+++ b/build_deps/toolchains/redis/redis-plus-plus.BUILD
@@ -1,4 +1,4 @@
-load("@rules_foreign_cc//tools/build_defs:cmake.bzl", "cmake_external")
+load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 load(
     "@local_config_tf//:build_defs.bzl",
     "D_GLIBCXX_USE_CXX11_ABI",
@@ -16,7 +16,7 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 
-cmake_external(
+cmake(
     name = "redis-plus-plus",
     cache_entries = {
         # CMake's find_package wants to find cmake config for liba,
@@ -27,13 +27,13 @@ cmake_external(
         "HIREDIS_LIB": "$EXT_BUILD_DEPS/hiredis/lib",
         "HIREDIS_HEADER": "$EXT_BUILD_DEPS/hiredis/include",
     },
-    cmake_options = [
+    generate_args = [
         "-DCMAKE_BUILD_TYPE=Release",
         "-DREDIS_PLUS_PLUS_BUILD_TEST=OFF",
         "-DREDIS_PLUS_PLUS_CXX_STANDARD=11",
         "-DCMAKE_CXX_FLAGS="+D_GLIBCXX_USE_CXX11_ABI,
     ],
     lib_source = "@redis-plus-plus//:all_srcs",
-    static_libraries = ["libredis++.a"],
+    out_static_libs = ["libredis++.a"],
     deps = ["@hiredis"],
 )

--- a/configure.py
+++ b/configure.py
@@ -55,6 +55,10 @@ def is_linux():
   return platform.system() == "Linux"
 
 
+def is_arm64():
+  return platform.machine() == "arm64"
+
+
 def is_raspi_arm():
   return os.uname()[4] == "armv7l"
 
@@ -205,7 +209,8 @@ def create_build_configuration():
     write("build:windows --copt=/arch=AVX")
 
   if is_macos() or is_linux():
-    write("build --copt=-mavx")
+    if not is_arm64():
+      write("build --copt=-mavx")
 
   if os.getenv("TF_NEED_CUDA", "0") == "1":
     print("> Building GPU & CPU ops")

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -14,7 +14,6 @@ limitations under the License.
 ==============================================================================*/
 
 #include <inttypes.h>
-#include <nmmintrin.h>
 #include <sw/redis++/connection.h>
 #include <sw/redis++/connection_pool.h>
 #include <sw/redis++/redis++.h>


### PR DESCRIPTION
# Description

Updated rules_foreign_cc from 0.0.9 to 0.6.0, modified API names according to its document.

Picked Heka's commit which modified Redis backend for supporting Arm64.


## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Tested building hiredis and redis++ on macOS Arm64 m1 machine.
