### PR TITLE
[CI] Install RocksDb and its dependency to CI docker image.

### DIFF
--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -23,6 +23,7 @@ RUN ln -sf /usr/local/bin/python$PY_VERSION /usr/bin/python
 # Use devtoolset-7 as tool chain
 RUN rm -r /usr/bin/gcc*
 ENV PATH=/dt7/usr/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/dt7/user/lib64:${LD_LIBRARY_PATH}
 ENV LD_LIBRARY_PATH=/dt7/user/lib:${LD_LIBRARY_PATH}
 ENV MANPATH=/dt7/user/share/man:${LD_LIBRARY_PATH}

--- a/tools/docker/cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile
+++ b/tools/docker/cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile
@@ -25,6 +25,11 @@ RUN apt-get update && apt-get install -y \
       xz-utils \
       libjpeg-dev \
       zlib1g-dev \
+      libgflags-dev \
+      libsnappy-dev \
+      libbz2-dev \
+      liblz4-dev \
+      libzstd-dev \
       && \
     rm -rf /var/lib/apt/lists/*
 
@@ -98,3 +103,9 @@ RUN /install/install_pip_packages_by_version.sh "/usr/local/bin/pip3.7"
 ENV CLANG_VERSION="r7f6f9f4cf966c78a315d15d6e913c43cfa45c47c"
 COPY install/install_latest_clang.sh /install/
 RUN /install/install_latest_clang.sh
+
+RUN ln -s /usr/lib/x86_64-linux-gnu/liblz4.so.1 /usr/local/lib/liblz4.so
+RUN ln -s /usr/lib/x86_64-linux-gnu/libzstd.so.1 /usr/local/lib/libzstd.so
+
+COPY install/install_rocksdb.sh /install/
+RUN /install/install_rocksdb.sh "6.22.1"

--- a/tools/docker/install/install_rocksdb.sh
+++ b/tools/docker/install/install_rocksdb.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Copyright 2021 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+# Select RocksDB version.
+ROCKSDB_VERSION=$1
+
+
+install_dir=${2:-"/usr/local/lib"}
+mkdir -p ${install_dir}
+mkdir -p /tmp
+cd /tmp
+rm -rf /tmp/v$ROCKSDB_VERSION.tar.gz
+wget -O /tmp/v$ROCKSDB_VERSION.tar.gz https://github.com/facebook/rocksdb/archive/refs/tags/v$ROCKSDB_VERSION.tar.gz >/dev/null
+tar -xvf /tmp/v$ROCKSDB_VERSION.tar.gz >/dev/null
+cd /tmp/rocksdb-$ROCKSDB_VERSION
+DEBUG_LEVEL=0 make static_lib -j EXTRA_CXXFLAGS="-fPIC -D_GLIBCXX_USE_CXX11_ABI=0" EXTRA_CFLAGS="-fPIC -D_GLIBCXX_USE_CXX11_ABI=0"
+chmod -R 777 /tmp/rocksdb-$ROCKSDB_VERSION/librocksdb.so*
+cp /tmp/rocksdb-$ROCKSDB_VERSION/librocksdb.so ${install_dir}
+rm -f /tmp/$ROCKSDB_VERSION.tar.gz
+rm -rf /tmp/rocksdb-${ROCKSDB_VERSION}
+
+# Enable bazel auto completion.
+echo "export LD_LIBRARY_PATH=/usr/local/lib/:$LD_LIBRARY_PATH" >> ~/.bashrc


### PR DESCRIPTION
- Install RocksDB and its deps to CI docker image by following [RocksDB install guide](https://github.com/facebook/rocksdb/blob/main/INSTALL.md).