### PR TITLE
[fix] Update valid bazel version numbers

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -25,10 +25,12 @@ import tensorflow as tf
 _TFRA_BAZELRC = ".bazelrc"
 
 # Maping TensorFlow version to valid Bazel version.
+# According to Tensorflow official document, the recommended bazel version for tensorflow 2.4.0
+# and 2.4.1 is 3.1.0. But rules_foreign_cc 0.6.0 requires bazel 3.7.0 + to build the code without bug.
 _VALID_BAZEL_VERSION = {
     "1.15.2": "0.26.1",
-    "2.4.0": "3.1.0",
-    "2.4.1": "3.1.0",
+    "2.4.0": "3.7.2",
+    "2.4.1": "3.7.2",
     "2.5.1": "3.7.2"
 }
 


### PR DESCRIPTION
# Description

Corrected the valid Bazel version numbers for Tensorflow 2.4.0 and 2.4.1 from 3.1.0 to 3.7.2
This pull request is to solve a known compiling error caused by updated rules foreign cc library 0.6.0.
The rules foreign cc 0.6.0 library requires Bazel 3.7.0 +.  

Fixes # (issue)

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Tested on other contributors' devices, the Bazel 3.7.0 + can build the project with Tensorflow 2.4.0 without error.

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
