### PR TITLE
[fix] add mpi & hvd installation to macOS CI and cpu_tests

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.7
       - run: pip install pygithub click
       - name: Check that the CODEOWNERS is valid
         run: python .github/workflows/notify_codeowners.py .github/CODEOWNERS

--- a/.github/workflows/make_wheel_macOS_x86.sh
+++ b/.github/workflows/make_wheel_macOS_x86.sh
@@ -6,8 +6,11 @@ if [ -z $HOROVOD_VERSION ] ; then
 fi
 python --version
 
-python -m pip install --default-timeout=1000 delocate==0.9.1 wheel setuptools tensorflow==$TF_VERSION \
-  horovod==$HOROVOD_VERSION
+brew install open-mpi
+
+python -m pip install --default-timeout=1000 delocate==0.9.1 wheel setuptools tensorflow==$TF_VERSION
+bash tools/docker/install/install_horovod.sh $HOROVOD_VERSION --only-cpu
+
 bash tools/testing/build_and_run_tests.sh
 
 bazel build \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
         # TODO: add back 'Windows' when it can be compiled.
         os: ['macOS', 'Linux']
         py-version: ['3.7', '3.8', '3.9']
-        tf-version: ['2.5.1', '2.7.0']
+        tf-version: ['2.5.1']
         tf-need-cuda: ['1', '0']
         cpu: ['x86']
 #       TODO(poinwater): add macOS CI once GitHub supports macOS 12.0.0 + 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ on:
       - r*
 
 env:
-  MIN_PY_VERSION: '3.6'
+  MIN_PY_VERSION: '3.7'
   MAX_PY_VERSION: '3.9'
   USE_BAZEL_VERSION: "3.7.2"
   HOROVOD_VERSION: '0.23.0'

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Check [nvidia-support-matrix](https://docs.nvidia.com/deeplearning/cudnn/support
 - Due to the significant changes in the Tensorflow API, we can only ensure version 0.2.0 compatibility with TF1.15.2 on CPU & GPU, 
   but **there are no official releases**, you can only get it through compiling by the following:
 ```shell
-PY_VERSION="3.6" \
+PY_VERSION="3.7" \
 TF_VERSION="1.15.2" \
 TF_NEED_CUDA=1 \
 sh .github/workflows/make_wheel_Linux.sh

--- a/build_deps/tf_header/README.md
+++ b/build_deps/tf_header/README.md
@@ -24,5 +24,5 @@ cp -r $_BAZEL_CACHE_DIR $TFRA_HOME/build_deps/tf_header/$TF_VERSION/
 
 5. Start compiling TFRA
 ```shell script
-PY_VERSION="3.6" TF_VERSION="1.15.2" TF_NEED_CUDA=0 sh .github/workflows/make_wheel_Linux.sh
+PY_VERSION="3.7" TF_VERSION="1.15.2" TF_NEED_CUDA=0 sh .github/workflows/make_wheel_Linux.sh
 ```

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,8 @@ def get_project_name_version():
 
   if "--nightly" in sys.argv:
     project_name = "tfra-nightly"
+    if os.getenv("TF_NEED_CUDA", "0") == "1":
+      project_name = project_name + "-gpu"
     version["__version__"] += get_last_commit_time()
     sys.argv.remove("--nightly")
 

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -3,12 +3,18 @@ FROM python:3.6 as build_wheel
 
 ARG TF_VERSION=2.5.1
 ARG USE_BAZEL_VERSION=3.7.2
+ARG MPI_VERSION="4.1.1"
+ARG HOROVOD_VERSION="0.23.0"
 
 RUN pip install --default-timeout=1000 tensorflow-cpu==$TF_VERSION
 
-RUN apt-get update && apt-get install -y sudo rsync cmake
-COPY tools/docker/install/install_bazel.sh ./
-RUN ./install_bazel.sh $USE_BAZEL_VERSION
+RUN apt-get update && apt-get install -y sudo rsync cmake openmpi-bin libopenmpi-dev
+
+COPY tools/docker/install/install_bazel.sh /install/
+RUN  /install/install_bazel.sh $USE_BAZEL_VERSION
+
+COPY tools/docker/install/install_horovod.sh /install/
+RUN  /install/install_horovod.sh $HOROVOD_VERSION --only-cpu
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -1,5 +1,5 @@
 #syntax=docker/dockerfile:1.1.5-experimental
-FROM python:3.6 as build_wheel
+FROM python:3.7 as build_wheel
 
 ARG TF_VERSION=2.5.1
 ARG USE_BAZEL_VERSION=3.7.2
@@ -35,7 +35,7 @@ RUN bazel build --enable_runfiles build_pip_pkg
 RUN bazel-bin/build_pip_pkg artifacts
 
 
-FROM python:3.6
+FROM python:3.7
 
 COPY tools/install_deps/tensorflow-cpu.txt ./
 RUN pip install --default-timeout=1000 --upgrade --force-reinstall -r tensorflow-cpu.txt

--- a/tools/docker/pre-commit.Dockerfile
+++ b/tools/docker/pre-commit.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 COPY tools/install_deps /install_deps
 RUN pip install -r /install_deps/yapf.txt

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.1.5-experimental
 # -------------------------------
-FROM python:3.6 as yapf-test
+FROM python:3.7 as yapf-test
 
 COPY tools/install_deps/yapf.txt ./
 RUN pip install -r yapf.txt
@@ -10,7 +10,7 @@ RUN python tools/check_python_format.py
 RUN touch /ok.txt
 
 # -------------------------------
-FROM python:3.6 as source_code_test
+FROM python:3.7 as source_code_test
 
 ARG USE_BAZEL_VERSION
 
@@ -38,7 +38,7 @@ RUN pytest -v -s /recommenders-addons/tools/testing/
 RUN touch /ok.txt
 
 # -------------------------------
-FROM python:3.6 as valid_build_files
+FROM python:3.7 as valid_build_files
 
 ARG USE_BAZEL_VERSION
 
@@ -57,7 +57,7 @@ RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
 RUN touch /ok.txt
 
 # -------------------------------
-FROM python:3.6-alpine as clang-format
+FROM python:3.7-alpine as clang-format
 
 RUN apk add --no-cache git
 RUN git clone https://github.com/gabrieldemarmiesse/clang-format-lint-action.git
@@ -85,7 +85,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # docs tests
-FROM python:3.6 as docs_tests
+FROM python:3.7 as docs_tests
 
 ARG USE_BAZEL_VERSION
 
@@ -114,7 +114,7 @@ RUN touch /ok.txt
 
 # -------------------------------
 # test the editable mode
-FROM python:3.6 as test_editable_mode
+FROM python:3.7 as test_editable_mode
 
 ARG USE_BAZEL_VERSION
 

--- a/tools/run_gpu_tests.sh
+++ b/tools/run_gpu_tests.sh
@@ -9,6 +9,6 @@ docker build \
        --build-arg TF_VERSION=2.5.1 \
        --build-arg TF_NEED_CUDA=1 \
        --build-arg TF_NAME="tensorflow-gpu" \
-       --build-arg PY_VERSION=3.6 \
+       --build-arg PY_VERSION=3.7 \
        -t tfra_gpu_tests ./
 docker run --rm -t -v cache_bazel:/root/.cache/bazel --gpus=all tfra_gpu_tests


### PR DESCRIPTION
- [fix] add mpi & hvd installation to macOS CI and cpu_tests
- [CI] switch little tests to python3.7 for compatible with TF2.7
- [CI] fix release files name exist error and correct nightly whl name for GPU .