### PR TITLE
[fix] Fix an issue where tf_patch.py failed in TF >= 2.6.x.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -27,6 +27,20 @@ except ImportError:
   kinit2 = None
   pass  # for compatible with TF < 2.3.x
 
+try:
+  import tensorflow as tf
+  kinit_tf = tf.keras.initializers
+except ImportError:
+  kinit_tf = None
+  pass  # for compatible with TF >= 2.6.x
+
+try:
+  import keras as K
+  kinit_K = K.initializers
+except ImportError:
+  kinit_K = None
+  pass  # for compatible with standalone Keras
+
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.eager import context
 from tensorflow.python.framework import device as pydev
@@ -351,3 +365,7 @@ def patch_on_tf():
     kinit1.VarianceScaling.__call__ = __call__for_keras_init_v1
   if kinit2 is not None:
     kinit2.VarianceScaling.__call__ = __call__for_keras_init_v2
+  if kinit_tf is not None:
+    kinit_tf.VarianceScaling.__call__ = __call__for_keras_init_v2
+  if kinit_K is not None:
+    kinit_K.VarianceScaling.__call__ = __call__for_keras_init_v2


### PR DESCRIPTION
# Description

Fix an issue where tf_patch.py failed in TF >= 2.6.x. It cause by Keras detached from TF repo.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

try keras initializer in TF >= 2.6.x. And there is no full-size init warning.
