### PR TITLE
[feat] Add redis_hash_tags_hypodispersion and using_hash_storage_slice  to redis backend config. Change redis_connection_mode config, now redis_connection_mode = 2 will be standalone mode.

### DIFF
--- a/docs/api_docs/tfra/dynamic_embedding/RedisBackend.md
+++ b/docs/api_docs/tfra/dynamic_embedding/RedisBackend.md
@@ -24,7 +24,7 @@ Below is an example of a JSON file, along with comments on the corresponding pro
 **Attention! Json files cannot contain comments when actually used!**
 ```json
 {
-      "redis_connection_mode": 1,  // ClusterMode = 0, SentinelMode = 1, StreamMode = 2
+      "redis_connection_mode": 2,  // ClusterMode = 0, SentinelMode = 1, StandaloneMode = 2
       "redis_master_name": "master",
 
       // connection_options
@@ -44,14 +44,20 @@ Below is an example of a JSON file, along with comments on the corresponding pro
       "redis_connection_lifetime": 100,  // minutes
 
       // sentinel_connection_options
+      "redis_sentinel_user": "default",
+      "redis_sentinel_password": "",
       "redis_sentinel_connect_timeout": 1000,  // milliseconds
       "redis_sentinel_socket_timeout": 1000,  // milliseconds
 
       // Below there is user-defined parameters in this custom op, not Redis setting parameters
       "storage_slice_import": 2, // If storage_slice_import is not equal to storage_slice, rehash will happen. Equaling -1 means same as storage_slice.
       "storage_slice": 2,  // For deciding bucket number, which usually is how many Redis instance may be used in the trainning.
+      "using_hash_storage_slice":
+          False,  // If True, IDs will be calculated hash(CRC32) value and then MOD to decide which bucket number they belong to. If False, only calculate the remainder.
       "keys_sending_size": 1024,  // Determines how many keys to send at a time for performance tuning
       "using_md5_prefix_name": False,  // 1=true, 0=false
+      "redis_hash_tags_hypodispersion":
+          True,  // distribution of storag_slice will be hypodispersion in 16354 regardless cluster slot, but still depends on redis_hash_tags_import/runtime if they aren't empty.
       "model_tag_import": "test",  // model_tag_import for version and any other information from last time.
       "redis_hash_tags_import": ["{6379}","{26379}"], // Deciding hash tag for every bucket from last time, Note that the hash tag must be wrapped in curly braces {}.
       "model_tag_runtime": "test",  // model_tag_runtime for version and any other information for now.

--- a/docs/api_docs/tfra/dynamic_embedding/RedisTableConfig.md
+++ b/docs/api_docs/tfra/dynamic_embedding/RedisTableConfig.md
@@ -34,7 +34,7 @@ assign the embedding table starage properties.
 An example of a configuration file is shown below:
 ```python
 {
-  "redis_connection_mode": 1,
+  "redis_connection_mode": 2,
   "redis_master_name": "master",
   "redis_host_ip": [
     "127.0.0.1"
@@ -50,12 +50,16 @@ An example of a configuration file is shown below:
   "redis_conn_pool_size": 20,
   "redis_wait_timeout": 100000000,
   "redis_connection_lifetime": 100,
+  "redis_sentinel_user": "default",
+  "redis_sentinel_password": "",
   "redis_sentinel_connect_timeout": 1000,
   "redis_sentinel_socket_timeout": 1000,
   "storage_slice_import": 1,
   "storage_slice": 1,
+  "using_hash_storage_slice": False,
   "keys_sending_size": 1024,
   "using_md5_prefix_name": False,
+  "redis_hash_tags_hypodispersion": False,
   "model_tag_import": "test",
   "redis_hash_tags_import": [],
   "model_tag_runtime": "test",

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/README.md
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/README.md
@@ -24,7 +24,7 @@ Below is an example of a JSON file, along with comments on the corresponding pro
 **Attention! Json files cannot contain comments when actually used!**
 ```json
 {
-      "redis_connection_mode": 1,  // ClusterMode = 0, SentinelMode = 1, StreamMode = 2
+      "redis_connection_mode": 2,  // ClusterMode = 0, SentinelMode = 1, StandaloneMode = 2
       "redis_master_name": "master",
 
       // connection_options
@@ -44,14 +44,20 @@ Below is an example of a JSON file, along with comments on the corresponding pro
       "redis_connection_lifetime": 100,  // minutes
 
       // sentinel_connection_options
+      "redis_sentinel_user": "default",
+      "redis_sentinel_password": "",
       "redis_sentinel_connect_timeout": 1000,  // milliseconds
       "redis_sentinel_socket_timeout": 1000,  // milliseconds
 
       // Below there is user-defined parameters in this custom op, not Redis setting parameters
       "storage_slice_import": 2, // If storage_slice_import is not equal to storage_slice, rehash will happen. Equaling -1 means same as storage_slice.
       "storage_slice": 2,  // For deciding bucket number, which usually is how many Redis instance may be used in the trainning.
+      "using_hash_storage_slice":
+          False,  // If True, IDs will be calculated hash(CRC32) value and then MOD to decide which bucket number they belong to. If False, only calculate the remainder.
       "keys_sending_size": 1024,  // Determines how many keys to send at a time for performance tuning
       "using_md5_prefix_name": False,  // 1=true, 0=false
+      "redis_hash_tags_hypodispersion":
+          False,  // distribution of storag_slice will be hypodispersion in 16354 regardless cluster slot, but still depends on redis_hash_tags_import/runtime if they aren't empty.
       "model_tag_import": "test",  // model_tag_import for version and any other information from last time.
       "redis_hash_tags_import": ["{6379}","{26379}"], // Deciding hash tag for every bucket from last time, Note that the hash tag must be wrapped in curly braces {}.
       "model_tag_runtime": "test",  // model_tag_runtime for version and any other information for now.

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
@@ -63,10 +63,10 @@ Status launchFindCore(std::shared_ptr<RedisVirtualWrapper> _table_instance,
                       std::vector<std::string> &keys_prefix_name_slices,
                       const Tensor &keys, Tensor *values,
                       const Tensor &default_value, const bool is_full_default,
-                      const int64 &Velems_per_flat2_dim0,
+                      const int64_t &Velems_per_flat2_dim0,
                       std::vector<ThreadContext *> &threads_Find,
-                      std::mutex &threads_Find_mutex, const int64 begin,
-                      const int64 end) {
+                      std::mutex &threads_Find_mutex, const int64_t begin,
+                      const int64_t end) {
   size_t thread_context_id =
       SelectAvailableThreadContext(threads_Find, threads_Find_mutex);
 
@@ -89,9 +89,9 @@ Status launchFindWithExistsCore(
     std::shared_ptr<RedisVirtualWrapper> _table_instance,
     std::vector<std::string> &keys_prefix_name_slices, const Tensor &keys,
     Tensor *values, const Tensor &default_value, Tensor &exists,
-    const bool is_full_default, const int64 &Velems_per_flat2_dim0,
+    const bool is_full_default, const int64_t &Velems_per_flat2_dim0,
     std::vector<ThreadContext *> &threads_Find, std::mutex &threads_Find_mutex,
-    const int64 begin, const int64 end) {
+    const int64_t begin, const int64_t end) {
   // TODO: Implement the function of not looking up the table if the key does
   // not exist
   size_t thread_context_id =
@@ -115,10 +115,10 @@ Status launchFindWithExistsCore(
 Status launchInsertCore(std::shared_ptr<RedisVirtualWrapper> _table_instance,
                         std::vector<std::string> &keys_prefix_name_slices,
                         const Tensor &keys, const Tensor &values,
-                        const int64 &Velems_per_flat2_dim0,
+                        const int64_t &Velems_per_flat2_dim0,
                         std::vector<ThreadContext *> &threads_Insert,
-                        std::mutex &threads_Insert_mutex, const int64 begin,
-                        const int64 end) {
+                        std::mutex &threads_Insert_mutex, const int64_t begin,
+                        const int64_t end) {
   size_t thread_context_id =
       SelectAvailableThreadContext(threads_Insert, threads_Insert_mutex);
 
@@ -135,10 +135,11 @@ Status launchInsertCore(std::shared_ptr<RedisVirtualWrapper> _table_instance,
 Status launchAccumCore(std::shared_ptr<RedisVirtualWrapper> _table_instance,
                        std::vector<std::string> &keys_prefix_name_slices,
                        const Tensor &keys, const Tensor &values_or_delta,
-                       const Tensor &exists, const int64 &Velems_per_flat2_dim0,
+                       const Tensor &exists,
+                       const int64_t &Velems_per_flat2_dim0,
                        std::vector<ThreadContext *> &threads_Insert,
-                       std::mutex &threads_Accum_mutex, const int64 begin,
-                       const int64 end) {
+                       std::mutex &threads_Accum_mutex, const int64_t begin,
+                       const int64_t end) {
   size_t thread_context_id =
       SelectAvailableThreadContext(threads_Insert, threads_Accum_mutex);
 
@@ -156,8 +157,8 @@ Status launchDeleteCore(std::shared_ptr<RedisVirtualWrapper> _table_instance,
                         std::vector<std::string> &keys_prefix_name_slices,
                         const Tensor &keys,
                         std::vector<ThreadContext *> &threads_Delete,
-                        std::mutex &threads_Delete_mutex, const int64 begin,
-                        const int64 end) {
+                        std::mutex &threads_Delete_mutex, const int64_t begin,
+                        const int64_t end) {
   size_t thread_context_id =
       SelectAvailableThreadContext(threads_Delete, threads_Delete_mutex);
 
@@ -340,6 +341,10 @@ Status ParseJsonConfig(const std::string *const redis_config_abs_dir,
 
   ReadOneJsonToParams(redis_connection_lifetime, integer);
 
+  ReadStringOneJsonToParams(redis_sentinel_user);
+
+  ReadStringOneJsonToParams(redis_sentinel_password);
+
   ReadOneJsonToParams(redis_sentinel_connect_timeout, integer);
 
   ReadOneJsonToParams(redis_sentinel_socket_timeout, integer);
@@ -353,9 +358,13 @@ Status ParseJsonConfig(const std::string *const redis_config_abs_dir,
           ? redis_connection_params->storage_slice_import
           : redis_connection_params->storage_slice;
 
+  ReadOneJsonToParams(using_hash_storage_slice, boolean);
+
   ReadOneJsonToParams(keys_sending_size, integer);
 
   ReadOneJsonToParams(using_md5_prefix_name, boolean);
+
+  ReadOneJsonToParams(redis_hash_tags_hypodispersion, boolean);
 
   ReadStringOneJsonToParams(model_tag_import);
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/redis_table_variable_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/redis_table_variable_test.py
@@ -295,6 +295,7 @@ redis_config_path = os.path.join(tempfile.mkdtemp(prefix=redis_config_dir),
 os.makedirs(redis_config_path)
 redis_config_path = os.path.join(redis_config_path, "redis_config.json")
 redis_config_params = {
+    "redis_connection_mode": 2,
     "redis_host_ip": ["127.0.0.1"],
     "redis_host_port": [6379],
     "storage_slice": 1,
@@ -326,6 +327,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=0,
           dim=8,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
       table.clear()
       self.evaluate(table.size())
@@ -374,6 +376,7 @@ class RedisVariableTest(test.TestCase):
             value_dtype=value_dtype,
             initializer=np.array([-1]).astype(_type_converter(value_dtype)),
             dim=dim,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
 
         table.clear()
@@ -447,6 +450,7 @@ class RedisVariableTest(test.TestCase):
             value_dtype=value_dtype,
             initializer=np.array([-1]).astype(_type_converter(value_dtype)),
             dim=dim,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
 
         table.clear()
@@ -525,12 +529,14 @@ class RedisVariableTest(test.TestCase):
           exported_exists = constant_op.constant([True, True, False, True],
                                                  dtype=dtypes.bool)
 
-          table = de.get_variable('taccum1-' + str(id),
-                                  key_dtype=key_dtype,
-                                  value_dtype=value_dtype,
-                                  initializer=np.array([-1]).astype(
-                                      _type_converter(value_dtype)),
-                                  dim=dim)
+          table = de.get_variable(
+              'taccum1-' + str(id),
+              key_dtype=key_dtype,
+              value_dtype=value_dtype,
+              initializer=np.array([-1]).astype(_type_converter(value_dtype)),
+              dim=dim,
+              devices=["/CPU:0"],
+              kv_creator=de.RedisTableCreator(config=redis_config))
           self.evaluate(table.clear())
 
           self.assertAllEqual(0, self.evaluate(table.size()))
@@ -583,6 +589,7 @@ class RedisVariableTest(test.TestCase):
             value_dtype=dtypes.float32,
             initializer=initializer,
             dim=10,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
         table.clear()
         vals_op = table.lookup(keys)
@@ -615,6 +622,7 @@ class RedisVariableTest(test.TestCase):
           dim=1,
           name="t1",
           initializer=-1.0,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config),
       )
       table.clear()
@@ -647,6 +655,7 @@ class RedisVariableTest(test.TestCase):
           name="t1",
           initializer=-1.0,
           checkpoint=True,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config),
       )
       table.clear()
@@ -703,6 +712,7 @@ class RedisVariableTest(test.TestCase):
           name="t1",
           initializer=default_val,
           checkpoint=True,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config),
       )
       table.clear()
@@ -737,6 +747,7 @@ class RedisVariableTest(test.TestCase):
           name="t1",
           initializer=default_val,
           checkpoint=True,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config),
       )
       table.clear()
@@ -796,6 +807,7 @@ class RedisVariableTest(test.TestCase):
           value_dtype=value_dtype,
           initializer=init_ops.random_normal_initializer(0.0, 0.01),
           dim=dim,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
       self.evaluate(params.clear())
       params_size = self.evaluate(params.size())
@@ -862,8 +874,6 @@ class RedisVariableTest(test.TestCase):
               np.sort(pairs_before[1], axis=0),
               np.sort(pairs_after[1], axis=0),
           )
-        if test_util.is_gpu_available():
-          self.assertTrue("GPU" in params.tables[0].resource_handle.device)
 
   def test_training_save_restore_by_files(self):
     if _redis_health_check(redis_config_params["redis_host_ip"][0],
@@ -908,6 +918,7 @@ class RedisVariableTest(test.TestCase):
           value_dtype=value_dtype,
           initializer=0,
           dim=dim,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config_modify))
 
       _, var0 = de.embedding_lookup(params,
@@ -971,6 +982,7 @@ class RedisVariableTest(test.TestCase):
             dtypes.int32,
             initializer=default_val,
             dim=2,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
         table2 = de.get_variable(
             "t1" + '_test_get_variable',
@@ -978,6 +990,7 @@ class RedisVariableTest(test.TestCase):
             dtypes.int32,
             initializer=default_val,
             dim=2,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
         table3 = de.get_variable(
             "t3" + '_test_get_variable',
@@ -985,6 +998,7 @@ class RedisVariableTest(test.TestCase):
             dtypes.int32,
             initializer=default_val,
             dim=2,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
 
         table1.clear()
@@ -1009,6 +1023,7 @@ class RedisVariableTest(test.TestCase):
             "t900",
             initializer=-1,
             dim=2,
+            devices=["/CPU:0"],
             kv_creator=de.RedisTableCreator(config=redis_config))
         with self.assertRaisesRegexp(ValueError,
                                      "Variable embedding/t900 already exists"):
@@ -1016,6 +1031,7 @@ class RedisVariableTest(test.TestCase):
               "t900",
               initializer=-1,
               dim=2,
+              devices=["/CPU:0"],
               kv_creator=de.RedisTableCreator(config=redis_config))
 
   @test_util.run_v1_only("Multiple sessions")
@@ -1038,6 +1054,7 @@ class RedisVariableTest(test.TestCase):
         dtypes.int32,
         initializer=0,
         dim=1,
+        devices=["/CPU:0"],
         kv_creator=de.RedisTableCreator(config=redis_config))
     self.evaluate(table.clear())
 
@@ -1080,6 +1097,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=default_val,
           dim=2,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
       table.clear()
 
@@ -1125,6 +1143,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=default_val,
           dim=2,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table1.clear()
@@ -1149,6 +1168,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=default_val,
           dim=2,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table2.clear()
@@ -1175,6 +1195,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=default_val,
           dim=2,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1219,6 +1240,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.float32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1249,6 +1271,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1277,6 +1300,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1304,6 +1328,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1337,6 +1362,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=default_val,
           dim=3,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1368,6 +1394,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int32,
           initializer=default_val,
           dim=3,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1402,18 +1429,21 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
       table2 = de.get_variable(
           "t192" + '_test_dynamic_embedding_variables',
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
       table3 = de.get_variable(
           "t193" + '_test_dynamic_embedding_variables',
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table1.clear()
@@ -1452,6 +1482,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1481,6 +1512,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.int32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1530,6 +1562,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.float32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1559,6 +1592,7 @@ class RedisVariableTest(test.TestCase):
           dtypes.int64,
           dtypes.float32,
           initializer=default_val,
+          devices=["/CPU:0"],
           kv_creator=de.RedisTableCreator(config=redis_config))
 
       table.clear()
@@ -1594,6 +1628,7 @@ class RedisVariableTest(test.TestCase):
         dim=embed_dim,
         init_size=256,
         restrict_policy=de.TimestampRestrictPolicy,
+        devices=["/CPU:0"],
         kv_creator=de.RedisTableCreator(config=redis_config))
 
     var_guard_by_tstp.clear()
@@ -1606,6 +1641,7 @@ class RedisVariableTest(test.TestCase):
         dim=embed_dim,
         init_size=256,
         restrict_policy=de.FrequencyRestrictPolicy,
+        devices=["/CPU:0"],
         kv_creator=de.RedisTableCreator(config=redis_config))
 
     var_guard_by_freq.clear()
@@ -1670,6 +1706,7 @@ class RedisVariableTest(test.TestCase):
         initializer=-1.,
         dim=embed_dim,
         restrict_policy=de.TimestampRestrictPolicy,
+        devices=["/CPU:0"],
         kv_creator=de.RedisTableCreator(config=redis_config))
 
     var_guard_by_tstp.clear()
@@ -1681,6 +1718,7 @@ class RedisVariableTest(test.TestCase):
         initializer=-1.,
         dim=embed_dim,
         restrict_policy=de.FrequencyRestrictPolicy,
+        devices=["/CPU:0"],
         kv_creator=de.RedisTableCreator(config=redis_config))
 
     var_guard_by_freq.clear()
@@ -1738,7 +1776,7 @@ class RedisVariableTest(test.TestCase):
     redis_config_path = os.path.join(save_path,
                                      "redis_config_modify_wrong_type.json")
     redis_config_params_raw_config = {
-        "redis_connection_mode": 1,
+        "redis_connection_mode": 2,
         "redis_master_name": "master",
         "redis_host_ip": ["127.0.0.1"],
         "redis_host_port": [6379],
@@ -1752,6 +1790,8 @@ class RedisVariableTest(test.TestCase):
         "redis_conn_pool_size": 20,
         "redis_wait_timeout": 100000000,
         "redis_connection_lifetime": 100,
+        "redis_sentinel_user": "default",
+        "redis_sentinel_password": "",
         "redis_sentinel_connect_timeout": 1000,
         "redis_sentinel_socket_timeout": 1000,
         "storage_slice": 4,
@@ -1873,4 +1913,5 @@ if __name__ == "__main__":
       os.popen('redis-cli -h ' + redis_config_params["redis_host_ip"][0] +
                ' -p ' + str(redis_config_params["redis_host_port"][0]) +
                ' FLUSHALL').read())
+  os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
   test.main()

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_creator.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_creator.py
@@ -117,7 +117,7 @@ class RedisTableConfig(object):
   An example of a configuration file is shown below:
   ```python
   {
-    "redis_connection_mode": 1,
+    "redis_connection_mode": 2,
     "redis_master_name": "master",
     "redis_host_ip": [
       "127.0.0.1"
@@ -133,12 +133,16 @@ class RedisTableConfig(object):
     "redis_conn_pool_size": 20,
     "redis_wait_timeout": 100000000,
     "redis_connection_lifetime": 100,
+    "redis_sentinel_user": "default",
+    "redis_sentinel_password": "",
     "redis_sentinel_connect_timeout": 1000,
     "redis_sentinel_socket_timeout": 1000,
     "storage_slice_import": 1,
     "storage_slice": 1,
+    "using_hash_storage_slice": False,
     "keys_sending_size": 1024,
     "using_md5_prefix_name": False,
+    "redis_hash_tags_hypodispersion": False,
     "model_tag_import": "test",
     "redis_hash_tags_import": [],
     "model_tag_runtime": "test",

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
@@ -59,7 +59,7 @@ class RedisTable(LookupInterface):
 
   default_redis_params = {
       "redis_connection_mode":
-          1,  # ClusterMode = 0, SentinelMode = 1, StreamMode = 2
+          1,  # ClusterMode = 0, SentinelMode = 1, StandaloneMode = 2
       "redis_master_name": "master",
       # connection_options
       "redis_host_ip": ["127.0.0.1"],
@@ -77,6 +77,8 @@ class RedisTable(LookupInterface):
       "redis_wait_timeout": 100000000,  # milliseconds
       "redis_connection_lifetime": 100,  # minutes
       # sentinel_connection_options
+      "redis_sentinel_user": "default",
+      "redis_sentinel_password": "",
       "redis_sentinel_connect_timeout": 1000,  # milliseconds
       "redis_sentinel_socket_timeout": 1000,  # milliseconds
       # Below there is user-defined parameters in this custom op, not Redis setting parameters
@@ -84,9 +86,13 @@ class RedisTable(LookupInterface):
           -1,  # If storage_slice_import is not equal to storage_slice, rehash will happen. Equaling -1 means same as storage_slice.
       "storage_slice":
           1,  # For deciding bucket number, which usually is how many Redis instance may be used in the trainning.
+      "using_hash_storage_slice":
+          False,  # If True, IDs will be calculated hash(CRC32) value and then MOD to decide which bucket number they belong to. If False, only calculate the remainder.
       "keys_sending_size":
           1024,  # Determines how many keys to send at a time for performance tuning
       "using_md5_prefix_name": False,  # 1=true, 0=false
+      "redis_hash_tags_hypodispersion":
+          False,  # distribution of storag_slice will be hypodispersion in 16354 regardless cluster slot, but still depends on redis_hash_tags_import/runtime if they aren't empty.
       "model_tag_import":
           "test",  #  model_tag_import for version and any other information from last time.
       "redis_hash_tags_import": [


### PR DESCRIPTION
# Description

Add redis_hash_tags_hypodispersion to redis backend config. 
If True, Distribution of storag_slice tag will be hypodispersion in 16354 regardless cluster slot, but still depends on redis_hash_tags_import/runtime if they aren't empty.

Add using_hash_storage_slice in redis config.
If True, IDs will be calculated hash(CRC32) value and then MOD to decide which bucket number they belong to.
If False, only calculate the remainder.

Change redis_connection_mode config, now redis_connection_mode = 2 will be standalone mode.

Also fix no redis sentinel password option in redis backend config.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [x] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

set redis_hash_tags_hypodispersion/using_hash_storage_slice to true or false in redis config.
