### PR TITLE
[fix] Fixed segment fault due to lambda may capture the thread_context reference with error address

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
@@ -172,8 +172,6 @@ class RedisWrapper<RedisInstance, K, V,
       } catch (const std::exception &err) {
         LOG(ERROR) << "RedisHandler error in PipeExecRead for slices "
                    << hkey.data() << " -- " << err.what();
-        error_ptr = std::current_exception();
-        throw(err);
       }
     } else {
       return nullptr;
@@ -194,8 +192,6 @@ class RedisWrapper<RedisInstance, K, V,
       } catch (const std::exception &err) {
         LOG(ERROR) << "RedisHandler error in PipeExecWrite for slices "
                    << hkey.data() << " -- " << err.what();
-        error_ptr = std::current_exception();
-        throw(err);
       }
     } else {
       return nullptr;
@@ -1004,7 +1000,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
     try {
       for (unsigned i = 0; i < storage_slice; ++i) {
         results.emplace_back(
-            network_worker_pool->enqueue([this, &cmd, &thread_context, i] {
+            network_worker_pool->enqueue([this, &cmd, thread_context, i] {
               return PipeExecRead(cmd, 3U, thread_context->buckets[i]);
             }));
       }
@@ -1228,7 +1224,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
     try {
       for (unsigned i = 0; i < storage_slice; ++i) {
         results.emplace_back(
-            network_worker_pool->enqueue([this, &cmd, &thread_context, i] {
+            network_worker_pool->enqueue([this, &cmd, thread_context, i] {
               return PipeExecWrite(cmd, 4U, thread_context->buckets[i]);
             }));
       }
@@ -1330,7 +1326,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
     try {
       for (unsigned i = 0; i < storage_slice; ++i) {
         results.emplace_back(
-            network_worker_pool->enqueue([this, &cmd, &thread_context, i] {
+            network_worker_pool->enqueue([this, &cmd, thread_context, i] {
               return PipeExecWrite(cmd, 6U, thread_context->buckets[i]);
             }));
       }
@@ -1411,7 +1407,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
     try {
       for (unsigned i = 0; i < storage_slice; ++i) {
         results.emplace_back(
-            network_worker_pool->enqueue([this, &cmd, &thread_context, i] {
+            network_worker_pool->enqueue([this, &cmd, thread_context, i] {
               return PipeExecWrite(cmd, 3U, thread_context->buckets[i]);
             }));
       }


### PR DESCRIPTION

# Description

Fixed segment fault due to lambda may capture the thread_context reference with error address when high concurrency and server disconnection.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

When inference mode, kill Redis server process.
