### PR TITLE
[Feat] Save and load cuckoo hashtable from hdfs

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,16 @@ http_archive(
     url = "https://github.com/sewenew/redis-plus-plus/archive/refs/tags/1.2.3.zip",
 )
 
+http_archive(
+    name = "hadoop",
+    build_file = "//third_party:hadoop.BUILD",
+    sha256 = "fa9d0587d06c36838e778081bcf8271a9c63060af00b3bf456423c1777a62043",
+    strip_prefix = "hadoop-rel-release-3.3.0",
+    urls = [
+        "https://github.com/apache/hadoop/archive/refs/tags/rel/release-3.3.0.tar.gz",
+    ],
+)
+
 tf_configure(
     name = "local_config_tf",
 )

--- a/build_deps/toolchains/redis/hiredis.BUILD
+++ b/build_deps/toolchains/redis/hiredis.BUILD
@@ -24,5 +24,5 @@ cmake(
         "-DCMAKE_INSTALL_LIBDIR=lib",
     ],
     lib_source = "@hiredis//:all_srcs",
-    out_static_libs = ["libhiredis_static.a"],
+    out_static_libs = ["libhiredis.a"],
 )

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/BUILD
@@ -29,7 +29,10 @@ custom_op_library(
         "utils/utils.h",
         "utils/types.h",
     ] + glob(["kernels/lookup_impl/lookup_table_op_gpu*"])),
-    deps = ["//tensorflow_recommenders_addons/dynamic_embedding/core/lib/cuckoo:cuckoohash"],
+    deps = [
+        "//tensorflow_recommenders_addons/dynamic_embedding/core/lib/cuckoo:cuckoohash",
+        "//tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system",
+    ],
 )
 
 custom_op_library(

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/BUILD
@@ -1,0 +1,19 @@
+load("@local_config_tf//:build_defs.bzl", "DTF_VERSION_INTEGER", "D_GLIBCXX_USE_CXX11_ABI")
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "hadoop_file_system",
+    srcs = ["hadoop_file_system.cc"],
+    hdrs = ["hadoop_file_system.h"],
+    copts = [
+        D_GLIBCXX_USE_CXX11_ABI,
+        DTF_VERSION_INTEGER,
+    ],
+    deps = [
+        "@hadoop",
+        "@local_config_tf//:libtensorflow_framework",
+        "@local_config_tf//:tf_header_lib",
+    ],
+    alwayslink = 1,
+)

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.cc
@@ -1,0 +1,595 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#if TF_VERSION_INTEGER >= 2070  // 2.7.0
+
+#include "hadoop_file_system.h"
+
+#include <errno.h>
+
+#include "hdfs/hdfs.h"
+#include "tensorflow/core/platform/env.h"
+#include "tensorflow/core/platform/error.h"
+#include "tensorflow/core/platform/file_system.h"
+#include "tensorflow/core/platform/file_system_helper.h"
+#include "tensorflow/core/platform/logging.h"
+#include "tensorflow/core/platform/mutex.h"
+#include "tensorflow/core/platform/path.h"
+#include "tensorflow/core/platform/status.h"
+#include "tensorflow/core/platform/strcat.h"
+
+namespace tensorflow {
+
+template <typename R, typename... Args>
+Status BindFunc(void* handle, const char* name,
+                std::function<R(Args...)>* func) {
+  void* symbol_ptr = nullptr;
+  TF_RETURN_IF_ERROR(
+      Env::Default()->GetSymbolFromLibrary(handle, name, &symbol_ptr));
+  *func = reinterpret_cast<R (*)(Args...)>(symbol_ptr);
+  return Status::OK();
+}
+
+class LibHDFS {
+ public:
+  LibHDFS() { LoadAndBind(); }
+
+  // The status, if any, from failure to load.
+  Status status() const { return status_; }
+
+  std::function<hdfsFS(hdfsBuilder*)> hdfsBuilderConnect;
+  std::function<hdfsBuilder*()> hdfsNewBuilder;
+  std::function<void(hdfsBuilder*, const char*)> hdfsBuilderSetNameNode;
+  std::function<int(const char*, char**)> hdfsConfGetStr;
+  std::function<int(hdfsFS, hdfsFile)> hdfsCloseFile;
+  std::function<tSize(hdfsFS, hdfsFile, tOffset, void*, tSize)> hdfsPread;
+  std::function<tSize(hdfsFS, hdfsFile, const void*, tSize)> hdfsWrite;
+  std::function<int(hdfsFS, hdfsFile)> hdfsHFlush;
+  std::function<int(hdfsFS, hdfsFile)> hdfsHSync;
+  std::function<tOffset(hdfsFS, hdfsFile)> hdfsTell;
+  std::function<hdfsFile(hdfsFS, const char*, int, int, short, tSize)>
+      hdfsOpenFile;
+  std::function<int(hdfsFS, const char*)> hdfsExists;
+  std::function<hdfsFileInfo*(hdfsFS, const char*, int*)> hdfsListDirectory;
+  std::function<void(hdfsFileInfo*, int)> hdfsFreeFileInfo;
+  std::function<int(hdfsFS, const char*, int recursive)> hdfsDelete;
+  std::function<int(hdfsFS, const char*)> hdfsCreateDirectory;
+  std::function<hdfsFileInfo*(hdfsFS, const char*)> hdfsGetPathInfo;
+  std::function<int(hdfsFS, const char*, const char*)> hdfsRename;
+
+ private:
+  void LoadAndBind() {
+    auto TryLoadAndBind = [this](const char* name, void** handle) -> Status {
+      TF_RETURN_IF_ERROR(Env::Default()->LoadDynamicLibrary(name, handle));
+#define BIND_HDFS_FUNC(function) \
+  TF_RETURN_IF_ERROR(BindFunc(*handle, #function, &function));
+
+      BIND_HDFS_FUNC(hdfsBuilderConnect);
+      BIND_HDFS_FUNC(hdfsNewBuilder);
+      BIND_HDFS_FUNC(hdfsBuilderSetNameNode);
+      BIND_HDFS_FUNC(hdfsConfGetStr);
+      BIND_HDFS_FUNC(hdfsCloseFile);
+      BIND_HDFS_FUNC(hdfsPread);
+      BIND_HDFS_FUNC(hdfsWrite);
+      BIND_HDFS_FUNC(hdfsHFlush);
+      BIND_HDFS_FUNC(hdfsTell);
+      BIND_HDFS_FUNC(hdfsHSync);
+      BIND_HDFS_FUNC(hdfsOpenFile);
+      BIND_HDFS_FUNC(hdfsExists);
+      BIND_HDFS_FUNC(hdfsListDirectory);
+      BIND_HDFS_FUNC(hdfsFreeFileInfo);
+      BIND_HDFS_FUNC(hdfsDelete);
+      BIND_HDFS_FUNC(hdfsCreateDirectory);
+      BIND_HDFS_FUNC(hdfsGetPathInfo);
+      BIND_HDFS_FUNC(hdfsRename);
+#undef BIND_HDFS_FUNC
+      return Status::OK();
+    };
+
+// libhdfs.so won't be in the standard locations. Use the path as specified
+// in the libhdfs documentation.
+#if defined(PLATFORM_WINDOWS)
+    const char* kLibHdfsDso = "hdfs.dll";
+#elif defined(MACOS) || defined(TARGET_OS_MAC)
+    const char* kLibHdfsDso = "libhdfs.dylib";
+#else
+    const char* kLibHdfsDso = "libhdfs.so";
+#endif
+    char* hdfs_home = getenv("HADOOP_HDFS_HOME");
+    if (hdfs_home != nullptr) {
+      string path = io::JoinPath(hdfs_home, "lib", "native", kLibHdfsDso);
+      status_ = TryLoadAndBind(path.c_str(), &handle_);
+      if (status_.ok()) {
+        return;
+      } else {
+        LOG(ERROR) << "HadoopFileSystem load error: "
+                   << status_.error_message();
+      }
+    }
+
+    // Try to load the library dynamically in case it has been installed
+    // to a in non-standard location.
+    status_ = TryLoadAndBind(kLibHdfsDso, &handle_);
+  }
+
+  Status status_;
+  void* handle_ = nullptr;
+};
+
+HadoopFileSystem::HadoopFileSystem() {}
+
+HadoopFileSystem::~HadoopFileSystem() {}
+
+const LibHDFS* libhdfs() {
+  static const LibHDFS* libhdfs = new LibHDFS();
+  return libhdfs;
+}
+
+Status SplitArchiveNameAndPath(StringPiece& path, string& nn) {
+  size_t index_end_archive_name = path.find(".har");
+  if (index_end_archive_name == path.npos) {
+    return errors::InvalidArgument(
+        "Hadoop archive path does not contain a .har extension");
+  }
+  // Case of hadoop archive. Namenode is the path to the archive.
+  std::ostringstream namenodestream;
+  namenodestream << "har://" << nn
+                 << path.substr(0, index_end_archive_name + 4);
+  nn = namenodestream.str();
+  path.remove_prefix(index_end_archive_name + 4);
+  if (path.empty()) {
+    // Root of the archive
+    path = "/";
+  }
+  return Status::OK();
+}
+
+// We implement connection caching in Tensorflow, which can significantly
+// improve performance. Fixes #43187
+Status HadoopFileSystem::Connect(StringPiece fname, hdfsFS* fs) {
+  TF_RETURN_IF_ERROR(libhdfs()->status());
+
+  StringPiece scheme, namenode, path;
+  io::ParseURI(fname, &scheme, &namenode, &path);
+  string nn(namenode);
+
+  string cacheKey(scheme.data(), scheme.size());
+  if (scheme == "file") {
+    nn = "";
+  } else if (scheme == "viewfs") {
+    char* defaultFS = nullptr;
+    libhdfs()->hdfsConfGetStr("fs.defaultFS", &defaultFS);
+    StringPiece defaultScheme, defaultCluster, defaultPath;
+    io::ParseURI(defaultFS, &defaultScheme, &defaultCluster, &defaultPath);
+
+    if (scheme != defaultScheme ||
+        (namenode != "" && namenode != defaultCluster)) {
+      return errors::Unimplemented(
+          "viewfs is only supported as a fs.defaultFS.");
+    }
+    // The default NameNode configuration will be used (from the XML
+    // configuration files). See:
+    // https://github.com/tensorflow/tensorflow/blob/v1.0.0/third_party/hadoop/hdfs.h#L259
+    nn = "default";
+  } else if (scheme == "har") {
+    TF_RETURN_IF_ERROR(SplitArchiveNameAndPath(path, nn));
+  } else {
+    if (nn.empty()) {
+      nn = "default";
+    }
+  }
+  cacheKey += nn;
+  {
+    mutex_lock lock(mu_);
+    if (connectionCache_.find(cacheKey) == connectionCache_.end()) {
+      hdfsBuilder* builder = libhdfs()->hdfsNewBuilder();
+      libhdfs()->hdfsBuilderSetNameNode(builder,
+                                        nn.empty() ? nullptr : nn.c_str());
+      hdfsFS cacheFs = libhdfs()->hdfsBuilderConnect(builder);
+      if (cacheFs == nullptr) {
+        return errors::Aborted(strerror(errno));
+      }
+      connectionCache_[cacheKey] = cacheFs;
+    }
+    *fs = connectionCache_[cacheKey];
+  }
+  return Status::OK();
+}
+
+string HadoopFileSystem::TranslateName(const string& name) const {
+  StringPiece scheme, namenode, path;
+  io::ParseURI(name, &scheme, &namenode, &path);
+  return string(path);
+}
+
+class HDFSRandomAccessFile : public RandomAccessFile {
+ public:
+  HDFSRandomAccessFile(const string& filename, const string& hdfs_filename,
+                       hdfsFS fs, hdfsFile file)
+      : filename_(filename),
+        hdfs_filename_(hdfs_filename),
+        fs_(fs),
+        file_(file) {
+    const char* disable_eof_retried = getenv("HDFS_DISABLE_READ_EOF_RETRIED");
+    if (disable_eof_retried && disable_eof_retried[0] == '1') {
+      disable_eof_retried_ = true;
+    } else {
+      disable_eof_retried_ = false;
+    }
+  }
+
+  ~HDFSRandomAccessFile() override {
+    if (file_ != nullptr) {
+      mutex_lock lock(mu_);
+      libhdfs()->hdfsCloseFile(fs_, file_);
+    }
+  }
+
+  Status Name(StringPiece* result) const override {
+    *result = filename_;
+    return Status::OK();
+  }
+
+  Status Read(uint64 offset, size_t n, StringPiece* result,
+              char* scratch) const override {
+    Status s;
+    char* dst = scratch;
+    bool eof_retried = false;
+    if (disable_eof_retried_) {
+      // eof_retried = true, avoid calling hdfsOpenFile in Read, Fixes #42597
+      eof_retried = true;
+    }
+    while (n > 0 && s.ok()) {
+      // We lock inside the loop rather than outside so we don't block other
+      // concurrent readers.
+      mutex_lock lock(mu_);
+      // Max read length is INT_MAX-2, for hdfsPread function take a parameter
+      // of int32. -2 offset can avoid JVM OutOfMemoryError.
+      size_t read_n =
+          std::min(n, static_cast<size_t>(std::numeric_limits<int>::max() - 2));
+      tSize r = libhdfs()->hdfsPread(fs_, file_, static_cast<tOffset>(offset),
+                                     dst, static_cast<tSize>(read_n));
+      if (r > 0) {
+        dst += r;
+        n -= r;
+        offset += r;
+      } else if (!eof_retried && r == 0) {
+        // Always reopen the file upon reaching EOF to see if there's more data.
+        // If writers are streaming contents while others are concurrently
+        // reading, HDFS requires that we reopen the file to see updated
+        // contents.
+        //
+        // Fixes #5438
+        if (file_ != nullptr && libhdfs()->hdfsCloseFile(fs_, file_) != 0) {
+          return IOError(filename_, errno);
+        }
+        file_ = libhdfs()->hdfsOpenFile(fs_, hdfs_filename_.c_str(), O_RDONLY,
+                                        0, 0, 0);
+        if (file_ == nullptr) {
+          return IOError(filename_, errno);
+        }
+        eof_retried = true;
+      } else if (eof_retried && r == 0) {
+        s = Status(error::OUT_OF_RANGE, "Read less bytes than requested");
+      } else if (errno == EINTR || errno == EAGAIN) {
+        // hdfsPread may return EINTR too. Just retry.
+      } else {
+        s = IOError(filename_, errno);
+      }
+    }
+    *result = StringPiece(scratch, dst - scratch);
+    return s;
+  }
+
+ private:
+  string filename_;
+  string hdfs_filename_;
+  hdfsFS fs_;
+  bool disable_eof_retried_;
+
+  mutable mutex mu_;
+  mutable hdfsFile file_ TF_GUARDED_BY(mu_);
+};
+
+Status HadoopFileSystem::NewRandomAccessFile(
+    const string& fname, TransactionToken* token,
+    std::unique_ptr<RandomAccessFile>* result) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+
+  hdfsFile file = libhdfs()->hdfsOpenFile(fs, TranslateName(fname).c_str(),
+                                          O_RDONLY, 0, 0, 0);
+  if (file == nullptr) {
+    return IOError(fname, errno);
+  }
+  result->reset(
+      new HDFSRandomAccessFile(fname, TranslateName(fname), fs, file));
+  return Status::OK();
+}
+
+class HDFSWritableFile : public WritableFile {
+ public:
+  HDFSWritableFile(const string& fname, hdfsFS fs, hdfsFile file)
+      : filename_(fname), fs_(fs), file_(file) {}
+
+  ~HDFSWritableFile() override {
+    if (file_ != nullptr) {
+      Close().IgnoreError();
+    }
+  }
+
+  Status Append(StringPiece data) override {
+    size_t cur_pos = 0, write_len = 0;
+    bool retry = false;
+    // max() - 2 can avoid OutOfMemoryError in JVM .
+    static const size_t max_len_once =
+        static_cast<size_t>(std::numeric_limits<tSize>::max() - 2);
+    while (cur_pos < data.size()) {
+      write_len = std::min(data.size() - cur_pos, max_len_once);
+      tSize w = libhdfs()->hdfsWrite(fs_, file_, data.data() + cur_pos,
+                                     static_cast<tSize>(write_len));
+      if (w == -1) {
+        if (!retry && (errno == EINTR || errno == EAGAIN)) {
+          retry = true;
+        } else {
+          return IOError(filename_, errno);
+        }
+      } else {
+        cur_pos += w;
+      }
+    }
+    return Status::OK();
+  }
+
+  Status Close() override {
+    Status result;
+    if (libhdfs()->hdfsCloseFile(fs_, file_) != 0) {
+      result = IOError(filename_, errno);
+    }
+    fs_ = nullptr;
+    file_ = nullptr;
+    return result;
+  }
+
+  Status Flush() override {
+    if (libhdfs()->hdfsHFlush(fs_, file_) != 0) {
+      return IOError(filename_, errno);
+    }
+    return Status::OK();
+  }
+
+  Status Name(StringPiece* result) const override {
+    *result = filename_;
+    return Status::OK();
+  }
+
+  Status Sync() override {
+    if (libhdfs()->hdfsHSync(fs_, file_) != 0) {
+      return IOError(filename_, errno);
+    }
+    return Status::OK();
+  }
+
+  Status Tell(int64* position) override {
+    *position = libhdfs()->hdfsTell(fs_, file_);
+    if (*position == -1) {
+      return IOError(filename_, errno);
+    }
+    return Status::OK();
+  }
+
+ private:
+  string filename_;
+  hdfsFS fs_;
+  hdfsFile file_;
+};
+
+Status HadoopFileSystem::NewWritableFile(
+    const string& fname, TransactionToken* token,
+    std::unique_ptr<WritableFile>* result) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+
+  hdfsFile file = libhdfs()->hdfsOpenFile(fs, TranslateName(fname).c_str(),
+                                          O_WRONLY, 0, 0, 0);
+  if (file == nullptr) {
+    return IOError(fname, errno);
+  }
+  result->reset(new HDFSWritableFile(fname, fs, file));
+  return Status::OK();
+}
+
+Status HadoopFileSystem::NewAppendableFile(
+    const string& fname, TransactionToken* token,
+    std::unique_ptr<WritableFile>* result) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+
+  hdfsFile file = libhdfs()->hdfsOpenFile(fs, TranslateName(fname).c_str(),
+                                          O_WRONLY | O_APPEND, 0, 0, 0);
+  if (file == nullptr) {
+    return IOError(fname, errno);
+  }
+  result->reset(new HDFSWritableFile(fname, fs, file));
+  return Status::OK();
+}
+
+Status HadoopFileSystem::NewReadOnlyMemoryRegionFromFile(
+    const string& fname, TransactionToken* token,
+    std::unique_ptr<ReadOnlyMemoryRegion>* result) {
+  // hadoopReadZero() technically supports this call with the following
+  // caveats:
+  // - It only works up to 2 GB. We'd have to Stat() the file to ensure that
+  //   it fits.
+  // - If not on the local filesystem, the entire file will be read, making
+  //   it inefficient for callers that assume typical mmap() behavior.
+  return errors::Unimplemented("HDFS does not support ReadOnlyMemoryRegion");
+}
+
+Status HadoopFileSystem::FileExists(const string& fname,
+                                    TransactionToken* token) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+  if (libhdfs()->hdfsExists(fs, TranslateName(fname).c_str()) == 0) {
+    return Status::OK();
+  }
+  return errors::NotFound(fname, " not found.");
+}
+
+Status HadoopFileSystem::GetChildren(const string& dir, TransactionToken* token,
+                                     std::vector<string>* result) {
+  result->clear();
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(dir, &fs));
+
+  // hdfsListDirectory returns nullptr if the directory is empty. Do a separate
+  // check to verify the directory exists first.
+  FileStatistics stat;
+  TF_RETURN_IF_ERROR(Stat(dir, token, &stat));
+
+  int entries = 0;
+  hdfsFileInfo* info =
+      libhdfs()->hdfsListDirectory(fs, TranslateName(dir).c_str(), &entries);
+  if (info == nullptr) {
+    if (stat.is_directory) {
+      // Assume it's an empty directory.
+      return Status::OK();
+    }
+    return IOError(dir, errno);
+  }
+  for (int i = 0; i < entries; i++) {
+    result->push_back(string(io::Basename(info[i].mName)));
+  }
+  libhdfs()->hdfsFreeFileInfo(info, entries);
+  return Status::OK();
+}
+
+Status HadoopFileSystem::GetMatchingPaths(const string& pattern,
+                                          TransactionToken* token,
+                                          std::vector<string>* results) {
+  return internal::GetMatchingPaths(this, Env::Default(), pattern, results);
+}
+
+Status HadoopFileSystem::DeleteFile(const string& fname,
+                                    TransactionToken* token) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+
+  if (libhdfs()->hdfsDelete(fs, TranslateName(fname).c_str(),
+                            /*recursive=*/0) != 0) {
+    return IOError(fname, errno);
+  }
+  return Status::OK();
+}
+
+Status HadoopFileSystem::CreateDir(const string& dir, TransactionToken* token) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(dir, &fs));
+
+  if (libhdfs()->hdfsCreateDirectory(fs, TranslateName(dir).c_str()) != 0) {
+    return IOError(dir, errno);
+  }
+  return Status::OK();
+}
+
+Status HadoopFileSystem::DeleteDir(const string& dir, TransactionToken* token) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(dir, &fs));
+
+  // Count the number of entries in the directory, and only delete if it's
+  // non-empty. This is consistent with the interface, but note that there's
+  // a race condition where a file may be added after this check, in which
+  // case the directory will still be deleted.
+  int entries = 0;
+  hdfsFileInfo* info =
+      libhdfs()->hdfsListDirectory(fs, TranslateName(dir).c_str(), &entries);
+  if (info != nullptr) {
+    libhdfs()->hdfsFreeFileInfo(info, entries);
+  }
+  // Due to HDFS bug HDFS-8407, we can't distinguish between an error and empty
+  // folder, especially for Kerberos enable setup, EAGAIN is quite common when
+  // the call is actually successful. Check again by Stat.
+  if (info == nullptr && errno != 0) {
+    FileStatistics stat;
+    TF_RETURN_IF_ERROR(Stat(dir, token, &stat));
+  }
+
+  if (entries > 0) {
+    return errors::FailedPrecondition("Cannot delete a non-empty directory.");
+  }
+  if (libhdfs()->hdfsDelete(fs, TranslateName(dir).c_str(),
+                            /*recursive=*/1) != 0) {
+    return IOError(dir, errno);
+  }
+  return Status::OK();
+}
+
+Status HadoopFileSystem::GetFileSize(const string& fname,
+                                     TransactionToken* token, uint64* size) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+
+  hdfsFileInfo* info =
+      libhdfs()->hdfsGetPathInfo(fs, TranslateName(fname).c_str());
+  if (info == nullptr) {
+    return IOError(fname, errno);
+  }
+  *size = static_cast<uint64>(info->mSize);
+  libhdfs()->hdfsFreeFileInfo(info, 1);
+  return Status::OK();
+}
+
+Status HadoopFileSystem::RenameFile(const string& src, const string& target,
+                                    TransactionToken* token) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(src, &fs));
+
+  if (libhdfs()->hdfsExists(fs, TranslateName(target).c_str()) == 0 &&
+      libhdfs()->hdfsDelete(fs, TranslateName(target).c_str(),
+                            /*recursive=*/0) != 0) {
+    return IOError(target, errno);
+  }
+
+  if (libhdfs()->hdfsRename(fs, TranslateName(src).c_str(),
+                            TranslateName(target).c_str()) != 0) {
+    return IOError(src, errno);
+  }
+  return Status::OK();
+}
+
+Status HadoopFileSystem::Stat(const string& fname, TransactionToken* token,
+                              FileStatistics* stats) {
+  hdfsFS fs = nullptr;
+  TF_RETURN_IF_ERROR(Connect(fname, &fs));
+
+  hdfsFileInfo* info =
+      libhdfs()->hdfsGetPathInfo(fs, TranslateName(fname).c_str());
+  if (info == nullptr) {
+    return IOError(fname, errno);
+  }
+  stats->length = static_cast<int64>(info->mSize);
+  stats->mtime_nsec = static_cast<int64>(info->mLastMod) * 1e9;
+  stats->is_directory = info->mKind == kObjectKindDirectory;
+  libhdfs()->hdfsFreeFileInfo(info, 1);
+  return Status::OK();
+}
+
+REGISTER_LEGACY_FILE_SYSTEM("hdfs", HadoopFileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("viewfs", HadoopFileSystem);
+REGISTER_LEGACY_FILE_SYSTEM("har", HadoopFileSystem);
+
+}  // namespace tensorflow
+
+#endif  // TF_VERSION_INTEGER >= 2070

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.h
@@ -1,0 +1,89 @@
+/* Copyright 2016 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#ifndef HADOOP_FILE_SYSTEM_H_
+#define HADOOP_FILE_SYSTEM_H_
+
+#include <map>
+
+#include "hdfs/hdfs.h"
+#include "tensorflow/core/platform/env.h"
+
+extern "C" {
+struct hdfs_internal;
+typedef hdfs_internal* hdfsFS;
+}
+
+namespace tensorflow {
+
+class LibHDFS;
+
+class HadoopFileSystem : public FileSystem {
+ public:
+  HadoopFileSystem();
+  ~HadoopFileSystem();
+
+  TF_USE_FILESYSTEM_METHODS_WITH_NO_TRANSACTION_SUPPORT;
+
+  Status NewRandomAccessFile(
+      const string& fname, TransactionToken* token,
+      std::unique_ptr<RandomAccessFile>* result) override;
+
+  Status NewWritableFile(const string& fname, TransactionToken* token,
+                         std::unique_ptr<WritableFile>* result) override;
+
+  Status NewAppendableFile(const string& fname, TransactionToken* token,
+                           std::unique_ptr<WritableFile>* result) override;
+
+  Status NewReadOnlyMemoryRegionFromFile(
+      const string& fname, TransactionToken* token,
+      std::unique_ptr<ReadOnlyMemoryRegion>* result) override;
+
+  Status FileExists(const string& fname, TransactionToken* token) override;
+
+  Status GetChildren(const string& dir, TransactionToken* token,
+                     std::vector<string>* result) override;
+
+  Status GetMatchingPaths(const string& pattern, TransactionToken* token,
+                          std::vector<string>* results) override;
+
+  Status DeleteFile(const string& fname, TransactionToken* token) override;
+
+  Status CreateDir(const string& dir, TransactionToken* token) override;
+
+  Status DeleteDir(const string& dir, TransactionToken* token) override;
+
+  Status GetFileSize(const string& fname, TransactionToken* token,
+                     uint64* size) override;
+
+  Status RenameFile(const string& src, const string& target,
+                    TransactionToken* token) override;
+
+  Status Stat(const string& fname, TransactionToken* token,
+              FileStatistics* stat) override;
+
+  string TranslateName(const string& name) const override;
+
+ private:
+  mutex mu_;
+  std::map<std::string, hdfsFS> connectionCache_ TF_GUARDED_BY(mu_);
+  Status Connect(StringPiece fname, hdfsFS* fs);
+};
+
+Status SplitArchiveNameAndPath(StringPiece& path, string& nn);
+
+}  // namespace tensorflow
+
+#endif  // HADOOP_FILE_SYSTEM_H_

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/cuckoo_hashtable_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/cuckoo_hashtable_ops.cc
@@ -254,6 +254,13 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableExport))
       return Status::OK();
     });
 
+REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableSaveToHDFS))
+    .Input("table_handle: resource")
+    .Input("filepath: string")
+    .Attr("key_dtype: type")
+    .Attr("value_dtype: type")
+    .Attr("buffer_size: int >= 1");
+
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableImport))
     .Input("table_handle: resource")
     .Input("keys: Tin")
@@ -269,6 +276,13 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableImport))
       TF_RETURN_IF_ERROR(c->Merge(keys, c->input(2), &keys));
       return Status::OK();
     });
+
+REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableLoadFromHDFS))
+    .Input("table_handle: resource")
+    .Input("filepath: string")
+    .Attr("key_dtype: type")
+    .Attr("value_dtype: type")
+    .Attr("buffer_size: int >= 1");
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableOfTensors))
     .Output("table_handle: resource")

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
@@ -338,6 +338,48 @@ class CuckooHashTable(LookupInterface):
             self.resource_handle, self._key_dtype, self._value_dtype)
     return keys, values
 
+  def save_to_hdfs(self, filepath, buffer_size=4194304, name=None):
+    """
+    Returns an operation to save the keys and values in table to
+    filepath. The keys and values will be stored in HDFS, appended to the filepath.
+    Args:
+      filepath: A path to save the table.
+      name: Name for the operation.
+      buffer_size: Number of kv pairs buffer write to file.
+    Returns:
+      An operation to save the table.
+    """
+    with ops.name_scope(name, "%s_save_table" % self.name,
+                        [self.resource_handle]):
+      with ops.colocate_with(None, ignore_existing=True):
+        return cuckoo_ops.tfra_cuckoo_hash_table_save_to_hdfs(
+            self.resource_handle,
+            filepath,
+            key_dtype=self._key_dtype,
+            value_dtype=self._value_dtype,
+            buffer_size=buffer_size)
+
+  def load_from_hdfs(self, filepath, buffer_size=4194304, name=None):
+    """
+    Returns an operation to load keys and values to table from
+    HDFS. The keys and values files are generated from `save_to_hdfs`.
+    Args:
+      filepath: A file path stored the table keys and values.
+      name: Name for the operation.
+      buffer_size: Number of kv pairs buffer to read file.
+    Returns:
+      An operation to load keys and values to table from HDFS.
+    """
+    with ops.name_scope(name, "%s_load_table" % self.name,
+                        [self.resource_handle]):
+      with ops.colocate_with(None, ignore_existing=True):
+        return cuckoo_ops.tfra_cuckoo_hash_table_load_from_hdfs(
+            self.resource_handle,
+            filepath,
+            key_dtype=self._key_dtype,
+            value_dtype=self._value_dtype,
+            buffer_size=buffer_size)
+
   def _gather_saveables_for_checkpoint(self):
     """For object-based checkpointing."""
     # full_name helps to figure out the name-based Saver's name for this saveable.

--- a/third_party/hadoop.BUILD
+++ b/third_party/hadoop.BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "hadoop",
+    hdrs = ["hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include/hdfs/hdfs.h"],
+    includes = ["hadoop-hdfs-project/hadoop-hdfs-native-client/src/main/native/libhdfs/include"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
# Description

Because of the storage mechanism of tensorflow, when the embedding table is large, the worker will consume a lot of memory, and eventually OOM.
This PR provides some methods to save or load files from hdfs for dynamic embedding tables.

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

In the test file, you need to replace the `filepath` with the real hdfs path. In addition, you need to add the header file `third_party/hadoop/hdfs.h` of hadoop in tensorflow.
