### PR TITLE
[Fix] Avoid double lookup of tables when using ShadowVariable when the Optimizer is updating gradients

### DIFF
--- a/build_deps/toolchains/gpu/cuda_configure.bzl
+++ b/build_deps/toolchains/gpu/cuda_configure.bzl
@@ -51,6 +51,14 @@ _TF_DOWNLOAD_CLANG = "TF_DOWNLOAD_CLANG"
 _PYTHON_BIN_PATH = "PYTHON_BIN_PATH"
 
 _DEFAULT_CUDA_COMPUTE_CAPABILITIES = {
+    "11.6": [
+        "6.0",
+        "6.1",
+        "7.0",
+        "7.5",
+        "8.0",
+        "8.6",
+    ],
     "11.5": [
         "6.0",
         "6.1",

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -104,7 +104,10 @@ def DynamicEmbeddingOptimizer(self, bp_v2=False, synchronous=False):
           var._track_optimizer_slots(_slots)
 
           with ops.control_dependencies([grad]):
-            v0 = var.read_value(do_prefetch=not var.params.bp_v2)
+            if isinstance(var, de.shadow_ops.ShadowVariable):
+              v0 = var.read_value(do_prefetch=False)
+            else:
+              v0 = var.read_value(do_prefetch=not var.params.bp_v2)
             s0 = [_s.read_value() for _s in _slots]
             _before = [v0] + s0
 
@@ -396,6 +399,7 @@ def create_slots(primary, init, slot_name, op_name, bp_v2):
           devices=params_var_.devices,
           partitioner=params_var_.partition_fn,
           initializer=init,
+          init_size=params_var_.init_size,
           kv_creator=params_var_.kv_creator,
           trainable=False,
           checkpoint=params_var_.checkpoint,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -362,14 +362,21 @@ class Variable(base.Trackable):
     while callable(init):
       if isinstance(init, valid_list):
         self.initializer = init
-        init = init(shape=[1])
+        init = init(shape=[dim])
       else:
         try:
           init = init(shape=[1])
         except:
           init = init()
     try:
-      init = array_ops.reshape(init, [dim])
+      init_dims = init.get_shape().as_list()
+      init_dims_mul = 1
+      for init_d in init_dims:
+        init_dims_mul = init_dims_mul * init_d
+      if init_dims_mul == dim:
+        init = array_ops.reshape(init, [dim])
+      else:
+        raise ValueError
     except:
       init = array_ops.fill([dim], array_ops.reshape(init, [-1])[0])
     init = math_ops.cast(init, dtype=self.value_dtype)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -87,7 +87,10 @@ class _DenseDynamicEmbeddingTrainableProcessor(optimizer._OptimizableVariable):
       self._v._track_optimizer_slots(_slots)
 
       with ops.control_dependencies([g]):
-        v0 = self._v.read_value(do_prefetch=not self._v.params.bp_v2)
+        if isinstance(self._v, de.shadow_ops.ShadowVariable):
+          v0 = self._v.read_value(do_prefetch=False)
+        else:
+          v0 = self._v.read_value(do_prefetch=not self._v.params.bp_v2)
         s0 = [_s.read_value() for _s in _slots]
         _before = [v0] + s0
 


### PR DESCRIPTION
# Description

Before this fix, in Keras model, ShadowVariable would read_value with do_prefetch twice when both embedding_lookup in forward calculation and apply_grad_to_update_var in backward calculation. For now, if var in apply_grad_to_update_var is ShadowVariable, read its value directly because it has been already done read_value with do_prefetch when in embedding_lookup function.

Also fix pass parameter init_size when create slot variable for de.Variable.

Also compatible with CUDA 11.6

Also modify _convert_anything_to_init function:
  1.Make output shape is dim when raw_init is a TF Initializer
  2.Make input dim is a constant op when using reshape op to prevent fault —— 
*** tensorflow.python.framework.errors_impl.InvalidArgumentError: Input to reshape is a tensor with 1 values, but the requested shape has 43
        Encountered when executing an operation using EagerExecutor. This error cancels all future operations and poisons their output tensors.

Also restrict Bazel building ram resources for Github CI memory limit

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
A test python script
```python
import tensorflow as tf
import numpy as np
import tensorflow_recommenders_addons as tfra
from tensorflow.keras import models, losses, layers, metrics, initializers

inp = {
    "f1": np.array([1,2,1,2,1,3,2,3]),
    # "f2": np.array([
    #     [1,2,3],
    #     [3,4,5],
    #     [1,2,3],
    #     [3,4,5],
    #     [3,2,5],
    #     [3,1,6],
    #     [2,1,2],
    #     [3,6,4]
    # ])
    "f2": np.array([
        [1,2,3],
        [3,4,5],
        [1,2,3],
        [3,4,5],
        [1,2,3],
        [3,4,5],
        [1,2,3],
        [3,4,5]
    ])
}

label = np.array([1,1,1,1,1,1,1,1])
merge_ds = tf.data.Dataset.from_tensor_slices((inp, label))

class TestModelTwoFeatures(tf.keras.Model):
    def __init__(self):
        super(TestModelTwoFeatures, self).__init__()
        self.embedding_size=5
        self.embed_layer = tfra.dynamic_embedding.get_variable(
            name="embed_layer",
            dim=self.embedding_size,
            devices=["CPU:0"],
            # initializer=initializers.RandomNormal(0, 0.1)
            initializer=1
        )
        self.dense = layers.Dense(1, activation="sigmoid")
    
    def call(self, batch):
        f1, f2 = batch["f1"], batch["f2"]
        f1_weights, f1_tw = tfra.dynamic_embedding.embedding_lookup(
            params=self.embed_layer,
            ids=f1,
            name="embed_weights_f1",
            return_trainable=True
        )
       
        f2_weights, f2_tw = tfra.dynamic_embedding.embedding_lookup(
            params=self.embed_layer,
            ids=f2,
            name="embed_weights_f2",
            return_trainable=True
        )
        
        f2_weights_merged = layers.GlobalAveragePooling1D()(f2_weights)
        
        final_weights = tf.concat([f1_weights, f2_weights_merged], axis=-1)
        output = self.dense(final_weights)
        return f1_weights, f2_weights, output, [f1_tw, f2_tw]

model = TestModelTwoFeatures()

optimizer = tf.keras.optimizers.SGD(learning_rate=0.001)
optimizer = tfra.dynamic_embedding.DynamicEmbeddingOptimizer(optimizer)

for i, (batch, label) in enumerate(merge_ds.batch(2)):
    print(f"batch No. = {i}")
    print(f"batch data = {batch}")
    print(f"batch_label = {label}")
    with tf.GradientTape() as tape:
        f1_weights, f2_weights, output, tws = model(batch)
        loss = losses.BinaryCrossentropy(from_logits=True)(label, output)
    grads = tape.gradient(loss, model.trainable_variables + tws)
    optimizer.apply_gradients(zip(grads, model.trainable_variables + tws))
    print(f"f1_weights = {f1_weights}")
    print(f"f2_weights = {f2_weights}")
    print()
```
