### PR TITLE
[Fix] In the case of bpv2, slot should not prefetch

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -102,7 +102,9 @@ def DynamicEmbeddingOptimizer(self, bp_v2=False, synchronous=False):
 
           with ops.control_dependencies([grad]):
             v0 = var.read_value(do_prefetch=not var.params.bp_v2)
-            s0 = [_s.read_value() for _s in _slots]
+            s0 = [
+                _s.read_value(do_prefetch=not var.params.bp_v2) for _s in _slots
+            ]
             _before = [v0] + s0
 
           if isinstance(grad, ops.IndexedSlices):


### PR DESCRIPTION
# Description

Brief Description of the PR:

In the case of bpv2, slot should not prefetch. If prefetch is set, then `S0` stores delta instead of the original value

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
