### PR TITLE
[fix] Fix bug that user self-defined variable name would be  modified to "TrainableWrapper" when Keras eager mode.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -220,8 +220,10 @@ class TrainableWrapper(resource_variable_ops.ResourceVariable):
       collections = list(collections) + [ops.GraphKeys.TRAINABLE_VARIABLES]
     with ops.init_scope():
       self._in_graph_mode = not context.executing_eagerly()
-      with ops.name_scope(name, "TrainableWrapper",
-                          [] if init_from_fn else [initial_value]) as name:
+      with ops.name_scope(name,
+                          "TrainableWrapper",
+                          [] if init_from_fn else [initial_value],
+                          skip_on_eager=False) as name:
         # pylint: disable=protected-access
         handle_name = ops.name_from_scope_name(name)
         handle_name = handle_name or "TrainableWrapperHandle"


### PR DESCRIPTION
# Description

Fix bug that user self-defined variable name would be  modified to "TrainableWrapperHandle" when Keras eager mode. Which code is copied from Tensorflow.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

when using BasicEmbedding in TFRA
