### PR TITLE
[fix] Compatible with compiling problem with TensorFlow version 2.4 and 2.8.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
@@ -1043,9 +1043,9 @@ class RedisTableOfTensors final : public LookupInterface {
 
   TensorShape value_shape() const override { return value_shape_; }
 
-  int64_t MemoryUsed() const override {
-    int64_t ret = 0;
-    ret = (int64_t)(size() * (sizeof(K) + sizeof(V)));
+  tensorflow::int64 MemoryUsed() const override {
+    tensorflow::int64 ret = 0;
+    ret = (tensorflow::int64)(size() * (sizeof(K) + sizeof(V)));
     return sizeof(RedisTableOfTensors) + ret;
   }
 };

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.cc
@@ -21,7 +21,6 @@ limitations under the License.
 
 #include "hdfs/hdfs.h"
 #include "tensorflow/core/platform/env.h"
-#include "tensorflow/core/platform/error.h"
 #include "tensorflow/core/platform/file_system.h"
 #include "tensorflow/core/platform/file_system_helper.h"
 #include "tensorflow/core/platform/logging.h"
@@ -29,6 +28,12 @@ limitations under the License.
 #include "tensorflow/core/platform/path.h"
 #include "tensorflow/core/platform/status.h"
 #include "tensorflow/core/platform/strcat.h"
+#if TF_VERSION_INTEGER >= 2080  // 2.8.0
+#include "tensorflow/core/platform/errors.h"
+using tensorflow::errors::IOError;
+#else
+#include "tensorflow/core/platform/error.h"
+#endif
 
 namespace tensorflow {
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/lib/nvhash/cudf/concurrent_unordered_map.cuh
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/lib/nvhash/cudf/concurrent_unordered_map.cuh
@@ -86,6 +86,11 @@ __inline__ __device__ float atomicCAS(float* address, float compare, float val)
   return __int_as_float(atomicCAS((int*)address, __float_as_int(compare), __float_as_int(val)));
 }
 
+__inline__ __device__ int64_t atomicAdd(long long* address, const long long val)
+{
+  return (int64_t) atomicAdd((unsigned long long*)address, (const unsigned long long)val);
+}
+
 __inline__ __device__ int64_t atomicAdd(int64_t* address, const int64_t val)
 {
   return (int64_t) atomicAdd((unsigned long long*)address, (const unsigned long long)val);


### PR DESCRIPTION
# Description

[fix] Compatible with tensorflow::int64 is "long long" instead of "in…t64_t" when TensorFlow version is 2.4 or below.

[fix] Compatible with "tensorflow/core/platform/errors.h" but not "tensorflow/core/platform/error.h" when tensorflow version is greater than 2.8.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Compile TFRA with TensorFlow version 2.4 and 2.8.
