### PR TITLE
[fix] Using hdfs file system with tensorflow version below 2.6.0.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/lib/hadoop_file_system/hadoop_file_system.cc
@@ -13,7 +13,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ==============================================================================*/
 
-#if TF_VERSION_INTEGER >= 2070  // 2.7.0
+#if TF_VERSION_INTEGER >= \
+    2060  // hdfs filesystem was migrate to tf_io in tf2.6.0
 
 #include "hadoop_file_system.h"
 


### PR DESCRIPTION
# Description

[fix] hdfs filesystem was migrate to tf_io in tf2.6.0 but not tf2.7.0

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Use it with tensorflow version 2.6.0.

