### PR TITLE
[fix] fix device of table shard was lost in savedmodel pb file when save model with keras api.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
@@ -60,6 +60,7 @@ class CuckooHashTable(LookupInterface):
       checkpoint=True,
       init_size=0,
       config=None,
+      device='',
   ):
     """Creates an empty `CuckooHashTable` object.
 
@@ -89,6 +90,7 @@ class CuckooHashTable(LookupInterface):
     self._checkpoint = checkpoint
     self._key_dtype = key_dtype
     self._value_dtype = value_dtype
+    self._device = device
     self._init_size = init_size
     self._name = name
 
@@ -123,15 +125,16 @@ class CuckooHashTable(LookupInterface):
     # explicitly specified.
     use_node_name_sharing = self._checkpoint and self._shared_name is None
 
-    table_ref = cuckoo_ops.tfra_cuckoo_hash_table_of_tensors(
-        shared_name=self._shared_name,
-        use_node_name_sharing=use_node_name_sharing,
-        key_dtype=self._key_dtype,
-        value_dtype=self._value_dtype,
-        value_shape=self._default_value.get_shape(),
-        init_size=self._init_size,
-        name=self._name,
-    )
+    with ops.device(self._device):
+      table_ref = cuckoo_ops.tfra_cuckoo_hash_table_of_tensors(
+          shared_name=self._shared_name,
+          use_node_name_sharing=use_node_name_sharing,
+          key_dtype=self._key_dtype,
+          value_dtype=self._value_dtype,
+          value_shape=self._default_value.get_shape(),
+          init_size=self._init_size,
+          name=self._name,
+      )
 
     if context.executing_eagerly():
       self._table_name = None

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -339,6 +339,7 @@ class Variable(base.Trackable):
                 name=self._make_name(idx),
                 checkpoint=self.checkpoint,
                 init_size=int(self.init_size / self.shard_num),
+                device=self.devices[idx],
             )
             self._tables.append(mht)
 


### PR DESCRIPTION
# Description

Fix device of table shard was lost in savedmodel pb file when save model with keras api. When use keras model saving, there is no device property in TFRA table resource node. So that, it would cause problem in serving scenes when load model with TF C++ api. That is when user want a CPU table but it was treated to a GPU table without enough device memory.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
In file 'tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding_test.py', a new test function 
'**test_keras_save_load_weights**'.