### PR TITLE
[Patch v0.3.2] fix: Reverse update logic within bp_v2

### DIFF
--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -91,6 +91,7 @@ jobs:
       run: |
         # Run on all notebooks to prevent upstream change.
         echo "Check formatting with nbfmt:"
+        python3 -m pip install --upgrade protobuf==3.19.6
         python3 -m tensorflow_docs.tools.nbfmt --test \
             $(find docs/tutorials/ -type f -name *.ipynb)
   nblint:
@@ -105,6 +106,7 @@ jobs:
       run: |
         # Run on all notebooks to prevent upstream change.
         echo "Lint check with nblint:"
+        python3 -m pip install --upgrade protobuf==3.19.6
         python3 -m tensorflow_docs.tools.nblint \
             --arg=repo:tensorflow/recommenders-addons \
             --exclude_lint=tensorflow::button_colab \

--- a/.github/workflows/ci_test.yml
+++ b/.github/workflows/ci_test.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.6
+          python-version: 3.8
       - run: pip install pygithub click
       - name: Check that the CODEOWNERS is valid
         run: python .github/workflows/notify_codeowners.py .github/CODEOWNERS

--- a/.github/workflows/make_wheel_Linux.sh
+++ b/.github/workflows/make_wheel_Linux.sh
@@ -12,7 +12,7 @@ else
 fi
 
 if [ $TF_VERSION == "2.5.1" ] ; then
-  export BUILD_IMAGE="tfra/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython"
+  export BUILD_IMAGE="tfra/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython:r0.3"
   export TF_CUDA_VERSION="11.2"
   export TF_CUDNN_VERSION="8.1"
 elif [ $TF_VERSION == "2.4.1" ] ; then

--- a/.github/workflows/make_wheel_Windows.sh
+++ b/.github/workflows/make_wheel_Windows.sh
@@ -6,6 +6,8 @@ export BAZEL_VC="C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/
 python -m pip install --default-timeout=1000 wheel setuptools tensorflow==$TF_VERSION
 bash ./tools/testing/build_and_run_tests.sh
 
+python -m pip install --upgrade protobuf==3.19.6
+
 python configure.py
 
 bazel.exe build  --no-cache \

--- a/.github/workflows/make_wheel_macOS.sh
+++ b/.github/workflows/make_wheel_macOS.sh
@@ -3,7 +3,7 @@ set -e -x
 export TF_NEED_CUDA=0
 
 python --version
-python -m pip install --default-timeout=1000 delocate==0.9.1 wheel setuptools tensorflow==$TF_VERSION
+python -m pip install --default-timeout=1000 delocate==0.9.1 wheel==0.37.0 setuptools==50.0.0 tensorflow==$TF_VERSION
 python -m pip install --upgrade protobuf==3.19.6
 
 bash tools/testing/build_and_run_tests.sh

--- a/.github/workflows/make_wheel_macOS.sh
+++ b/.github/workflows/make_wheel_macOS.sh
@@ -4,6 +4,7 @@ export TF_NEED_CUDA=0
 
 python --version
 python -m pip install --default-timeout=1000 delocate==0.9.1 wheel setuptools tensorflow==$TF_VERSION
+python -m pip install --upgrade protobuf==3.19.6
 
 bash tools/testing/build_and_run_tests.sh
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
           pip install --default-timeout=1000 -r tools/install_deps/pytest.txt -r tools/install_deps/tensorflow-cpu.txt -r requirements.txt
           sudo apt install -y redis > /dev/null 2> /dev/null
           bash tools/install_deps/install_bazelisk.sh ./
+          python -m pip install --upgrade protobuf==3.19.6
           python configure.py
           bazel test -c opt -k --test_timeout 300,450,1200,3600 --test_output=errors //tensorflow_recommenders_addons/...
   release-wheel:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
           # excludes cuda on macOS
           - os: 'macos-latest'
             tf-need-cuda: '1'
+          - os: 'macos-latest'
+            py-version: '3.6'
           # excludes TF1.15.2 on py38
           - py-version: '3.8'
             tf-version: '1.15.2'
@@ -131,6 +133,8 @@ jobs:
           # excludes cuda on macOS
           - os: 'macOS'
             tf-need-cuda: '1'
+          - os: 'macOS'
+            py-version: '3.6'
       fail-fast: false
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master') || github.event_name == 'release'
     steps:

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,8 +41,8 @@ http_archive(
 
 new_git_repository(
     name = "hiredis",
-    branch = "master",
     build_file = "//build_deps/toolchains/redis:hiredis.BUILD",
+    commit = "2d9d77518d012a54ae34f9822e4b4d19823c4b75",
     remote = "https://github.com/redis/hiredis.git",
 )
 

--- a/build_deps/toolchains/redis/hiredis.BUILD
+++ b/build_deps/toolchains/redis/hiredis.BUILD
@@ -21,8 +21,8 @@ cmake_external(
     cmake_options = [
         "-DCMAKE_BUILD_TYPE=Release",
         "-DCMAKE_CXX_FLAGS="+D_GLIBCXX_USE_CXX11_ABI,
+        "-DCMAKE_INSTALL_LIBDIR=lib",
     ],
     lib_source = "@hiredis//:all_srcs",
     static_libraries = ["libhiredis_static.a"],
 )
-

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -97,7 +97,7 @@ def DynamicEmbeddingOptimizer(self, bp_v2=None):
           var._track_optimizer_slots(_slots)
 
           with ops.control_dependencies([grad]):
-            v0 = var.read_value(do_prefetch=not var.params.bp_v2)
+            v0 = var.read_value(do_prefetch=var.params.bp_v2)
             s0 = [_s.read_value() for _s in _slots]
             _before = [v0] + s0
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -67,7 +67,7 @@ class _DenseDynamicEmbeddingTrainableProcessor(optimizer._OptimizableVariable):
       self._v._track_optimizer_slots(_slots)
 
       with ops.control_dependencies([g]):
-        v0 = self._v.read_value(do_prefetch=not self._v.params.bp_v2)
+        v0 = self._v.read_value(do_prefetch=self._v.params.bp_v2)
         s0 = [_s.read_value() for _s in _slots]
         _before = [v0] + s0
 

--- a/tensorflow_recommenders_addons/version.py
+++ b/tensorflow_recommenders_addons/version.py
@@ -23,7 +23,7 @@ MAX_TF_VERSION = os.getenv("TF_VERSION", "2.5.1")
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"
 _MINOR_VERSION = "3"
-_PATCH_VERSION = "1"
+_PATCH_VERSION = "2"
 
 # When building releases, we can update this value on the release branch to
 # reflect the current release candidate ('rc0', 'rc1') or, finally, the official

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -42,6 +42,8 @@ RUN python -m pip install -r /install_deps/pytest.txt
 COPY requirements.txt .
 RUN python -m pip install -r requirements.txt
 
+RUN python -m pip install --upgrade protobuf==3.19.6
+
 COPY ./ /recommenders-addons
 WORKDIR /recommenders-addons
 
@@ -83,6 +85,8 @@ FROM python:$PY_VERSION as test_wheel_in_fresh_environment
 ARG TF_VERSION
 ARG TF_NAME
 RUN python -m pip install --default-timeout=1000 $TF_NAME==$TF_VERSION
+
+RUN python -m pip install --upgrade protobuf==3.19.6
 
 COPY --from=make_wheel /recommenders-addons/wheelhouse/ /recommenders-addons/wheelhouse/
 RUN pip install /recommenders-addons/wheelhouse/*.whl

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -6,9 +6,7 @@ ARG USE_BAZEL_VERSION=3.7.2
 
 RUN pip install --default-timeout=1000 tensorflow-cpu==$TF_VERSION
 
-RUN apt-get update && apt-get install -y sudo rsync cmake
-COPY tools/docker/install/install_bazel.sh ./
-RUN ./install_bazel.sh $USE_BAZEL_VERSION
+RUN python -m pip install --upgrade protobuf==3.19.6
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
@@ -18,6 +16,9 @@ RUN pip install -r pytest.txt pytest-cov
 
 COPY ./ /recommenders-addons
 WORKDIR recommenders-addons
+
+RUN python -m pip install --upgrade protobuf==3.19.6
+
 RUN python configure.py
 RUN pip install -e ./
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
@@ -35,6 +36,8 @@ COPY tools/install_deps/tensorflow-cpu.txt ./
 RUN pip install --default-timeout=1000 --upgrade --force-reinstall -r tensorflow-cpu.txt
 
 COPY --from=0 /recommenders-addons/artifacts /artifacts
+
+RUN python -m pip install --upgrade protobuf==3.19.6
 
 RUN pip install /artifacts/tensorflow_recommenders_addons-*.whl
 

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -11,6 +11,8 @@ RUN python -m pip install --upgrade protobuf==3.19.6
 COPY tools/docker/install/install_bazel.sh ./
 RUN ./install_bazel.sh $USE_BAZEL_VERSION
 
+RUN apt-get update && apt-get install -y sudo rsync cmake
+
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 

--- a/tools/docker/cpu_tests.Dockerfile
+++ b/tools/docker/cpu_tests.Dockerfile
@@ -8,6 +8,9 @@ RUN pip install --default-timeout=1000 tensorflow-cpu==$TF_VERSION
 
 RUN python -m pip install --upgrade protobuf==3.19.6
 
+COPY tools/docker/install/install_bazel.sh ./
+RUN ./install_bazel.sh $USE_BAZEL_VERSION
+
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 

--- a/tools/docker/cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile
+++ b/tools/docker/cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile
@@ -44,19 +44,6 @@ COPY --from=devtoolset /dt8 /dt8
 
 RUN chmod 777 /tmp/
 
-# Install TensorRT.
-RUN echo \
-    deb https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu1604/x86_64 / \
-    > /etc/apt/sources.list.d/nvidia-ml.list \
-      && \
-    apt-get update && apt-get install -y \
-    libnvinfer-dev=7.1.3-1+cuda11.0 \
-    libnvinfer7=7.1.3-1+cuda11.0 \
-    libnvinfer-plugin-dev=7.1.3-1+cuda11.0 \
-    libnvinfer-plugin7=7.1.3-1+cuda11.0 \
-      && \
-    rm -rf /var/lib/apt/lists/*
-
 # Copy and run the install scripts.
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/tools/docker/cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile
+++ b/tools/docker/cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile
@@ -5,8 +5,8 @@
 #
 # To push a new version, run:
 # $ docker build -f cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython.Dockerfile . \
-#  --tag "tfra/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython"
-# $ docker push tfra/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython
+#  --tag "tfra/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython:r0.3"
+# $ docker push tfra/nosla-cuda11.2-cudnn8.1-ubuntu18.04-manylinux2010-multipython:r0.3
 
 FROM nvidia/cuda:11.2.0-cudnn8-devel-ubuntu18.04 as devtoolset
 

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -6,6 +6,8 @@ COPY tools/install_deps/yapf.txt ./
 RUN pip install -r yapf.txt
 COPY ./ /recommenders-addons
 WORKDIR /recommenders-addons
+
+RUN python -m pip install --upgrade protobuf==3.19.6
 RUN python tools/check_python_format.py
 RUN touch /ok.txt
 
@@ -30,6 +32,9 @@ COPY ./ /recommenders-addons
 RUN pip install -e /recommenders-addons
 
 WORKDIR /recommenders-addons
+
+RUN python -m pip install --upgrade protobuf==3.19.6
+
 RUN python configure.py
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/install_so_files.sh
@@ -51,6 +56,9 @@ RUN ./install_bazel.sh $USE_BAZEL_VERSION
 
 COPY ./ /recommenders-addons
 WORKDIR /recommenders-addons
+
+RUN python -m pip install --upgrade protobuf==3.19.6
+
 RUN python ./configure.py
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bazel build --nobuild -- //tensorflow_recommenders_addons/...
@@ -104,6 +112,8 @@ RUN ./install_bazel.sh $USE_BAZEL_VERSION
 COPY ./ /recommenders-addons
 WORKDIR /recommenders-addons
 
+RUN python -m pip install --upgrade protobuf==3.19.6
+
 RUN python configure.py
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/install_so_files.sh
@@ -131,6 +141,9 @@ RUN ./install_bazel.sh $USE_BAZEL_VERSION
 
 COPY ./ /recommenders-addons
 WORKDIR /recommenders-addons
+
+RUN python -m pip install --upgrade protobuf==3.19.6
+
 RUN python configure.py
 RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
     bash tools/install_so_files.sh


### PR DESCRIPTION
- [fix: Reverse update logic within bp_v2](https://github.com/tensorflow/recommenders-addons/pull/317)
For a longtime, we didn't publish any release on r0.3. There's a lot of change from dependencies caused the CI fail, so we have to cherry-pick many `[CI] fix xxxx` from master branch.