### PR TITLE
[fix] macOS arm64 build error

### DIFF
--- a/.github/workflows/make_wheel_macOS_arm64.sh
+++ b/.github/workflows/make_wheel_macOS_arm64.sh
@@ -2,17 +2,14 @@
 #
 # Making wheel for macOS arm64 architecture
 # Requirements: 
-# MacOS Monterey 12.0.0 +, Tensorflow-macos 2.5.0, ARM64 Apple Silicon, Bazel 4.1.0 +
+# MacOS Monterey 12.0.0 +, Tensorflow-macos 2.5.0, ARM64 Apple Silicon, Bazel 4.1.0 +, Python 3.8 or 3.9
 # Please don't install tensorflow-metal, it may cause incorrect GPU devices detection issue.
 set -e -x
 
-# Install CPU version
-export TF_NEED_CUDA=0
-
 python --version
 
-python -m pip install --default-timeout=1000 delocate==0.9.1 wheel==0.37.0 setuptools==50.0.0 tensorflow==$TF_VERSION
-python -m pip install --upgrade protobuf==3.19.6 numpy==1.19.4
+python -m pip install --default-timeout=1000 delocate==0.9.1 wheel==0.37.0 setuptools==50.0.0 tensorflow-macos==$TF_VERSION
+python -m pip install --upgrade protobuf==3.19.6 numpy==1.19.5
 
 python configure.py
 
@@ -27,5 +24,5 @@ bazel build \
   build_pip_pkg
 
 # Output the wheel file to the artifacts directory
-bazel-bin/build_pip_pkg artifacts "--plat-name macosx_12_0_arm64 $NIGHTLY_FLAG"
+bazel-bin/build_pip_pkg artifacts $NIGHTLY_FLAG
 delocate-wheel -w wheelhouse artifacts/*.whl

--- a/build_deps/build_pip_pkg.sh
+++ b/build_deps/build_pip_pkg.sh
@@ -17,6 +17,7 @@ set -e
 set -x
 
 PLATFORM="$(uname -s | tr 'A-Z' 'a-z')"
+ARCHITECTURE="$(uname -m)"
 
 function is_windows() {
   # On windows, the shell script is actually running in msys
@@ -25,6 +26,10 @@ function is_windows() {
 
 function is_macos() {
   [[ "${PLATFORM}" == "darwin" ]]
+}
+
+function is_arm64() {
+  [[ "${ARCHITECTURE}" == "arm64" ]]
 }
 
 if is_windows; then
@@ -77,7 +82,11 @@ function main() {
 
   BUILD_CMD="setup.py bdist_wheel --platlib-patch"
   if is_macos; then
-    BUILD_CMD="${BUILD_CMD} --plat-name macosx_10_13_x86_64"
+    if is_arm64; then
+      BUILD_CMD="${BUILD_CMD} --plat-name macosx_12_0_arm64"
+    else
+      BUILD_CMD="${BUILD_CMD} --plat-name macosx_10_13_x86_64"
+    fi
   fi
 
   if [[ -z ${NIGHTLY_FLAG} ]]; then

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/warm_start_util_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/warm_start_util_test.py
@@ -26,6 +26,7 @@ import os
 import shutil
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
+from tensorflow_recommenders_addons.utils.check_platform import is_macos, is_arm64
 
 try:
   from tensorflow.python.keras.initializers import initializers_v2 as kinit2
@@ -146,6 +147,10 @@ class WarmStartUtilTest(test.TestCase):
       self.assertAllEqual(emb, val_list)
 
   def _test_warm_start_estimator(self, num_shards, use_regex):
+    if (is_macos() and is_arm64()):
+      self.skipTest(
+          "skip save restore file system test because TFIO doesn't support apple silicon."
+      )
     devices = ["/cpu:0" for _ in range(num_shards)]
     ckpt_prefix = os.path.join(self.get_temp_dir(), "ckpt")
     id_list = [x for x in range(100)]

--- a/tensorflow_recommenders_addons/version.py
+++ b/tensorflow_recommenders_addons/version.py
@@ -15,6 +15,16 @@
 """Define TensorFlow Recommenders Addons version information."""
 
 import os
+import platform
+
+
+def is_macos():
+  return platform.system() == "Darwin"
+
+
+def is_arm64():
+  return platform.machine() == "arm64"
+
 
 # Required TensorFlow version [min, max)
 MIN_TF_VERSION = os.getenv("TF_VERSION", "2.5.0")


### PR DESCRIPTION
# Description

Brief Description of the PR:

This merge request addresses a building error that occurs when running the macOS arm64 make wheel script. The following changes were made to fix the issue:
- Updated the `Numpy` version to a compatible version.
- Corrected `tensorflow` to `tensorflow-macos`.
- Added the macOS arm64 check back to `check_platform.py`.
- Skipped failed tests due to Apple silicon not supporting `warm_up` and `hvd`.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  pytest
