### PR TITLE
[fix] fix some core dump cases and make usage of CUDA streams more reasonable. Also fix ineffective checkpoint setting.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
@@ -485,6 +485,9 @@ class RedisWrapper<RedisInstance, K, V,
       LOG(ERROR) << "RedisHandler error in HscanGetKeysValsInBucket for slices "
                  << keys_prefix_name_slice << " -- " << err.what();
     }
+    if (!reply.get()) {
+      return nullptr;
+    }
     if (reply->element[0]->type == REDIS_REPLY_STRING) {
       // #define REDIS_REPLY_STRING 1
       *cursor = std::atoll(reply->element[0]->str);

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -370,6 +370,9 @@ class RedisWrapper<
       LOG(ERROR) << "RedisHandler error in HscanGetKeysValsInBucket for slices "
                  << keys_prefix_name_slice << " -- " << err.what();
     }
+    if (!reply.get()) {
+      return nullptr;
+    }
     if (reply->element[0]->type == REDIS_REPLY_STRING) {
       // #define REDIS_REPLY_STRING 1
       *cursor = std::atoll(reply->element[0]->str);

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
@@ -596,6 +596,15 @@ class RedisTableOfTensors final : public LookupInterface {
               hscan_reply->elements > 1) {
             kvs_reply = hscan_reply->element[1];
             // fill Tensor keys and values
+            if constexpr (!std::is_same<V, tstring>::value) {
+              if (kvs_reply->element[0]->len !=
+                  runtime_value_dim_ * sizeof(V)) {
+                return errors::InvalidArgument(
+                    "Embedding dim in Redis server is not equal to the OP "
+                    "runtime "
+                    "dim.");
+              }
+            }
             for (size_t j = 0; j < kvs_reply->elements; ++j) {
               temp_reply = kvs_reply->element[j];
               if (temp_reply->type ==
@@ -1018,6 +1027,13 @@ class RedisTableOfTensors final : public LookupInterface {
         }
         kvs_reply = hscan_reply->element[1];
         // fill Tensor keys and values
+        if constexpr (!std::is_same<V, tstring>::value) {
+          if (kvs_reply->element[0]->len != runtime_value_dim_ * sizeof(V)) {
+            return errors::InvalidArgument(
+                "Embedding dim in Redis server is not equal to the OP runtime "
+                "dim.");
+          }
+        }
         for (size_t j = 0; j < kvs_reply->elements; ++j) {
           temp_reply = kvs_reply->element[j];
           if (temp_reply->type ==
@@ -1122,6 +1138,13 @@ class RedisTableOfTensors final : public LookupInterface {
         }
         kvs_reply = hscan_reply->element[1];
         // fill Tensor keys and values
+        if constexpr (!std::is_same<V, tstring>::value) {
+          if (kvs_reply->element[0]->len != runtime_value_dim_ * sizeof(V)) {
+            return errors::InvalidArgument(
+                "Embedding dim in Redis server is not equal to the OP runtime "
+                "dim.");
+          }
+        }
         for (size_t j = 0; j < kvs_reply->elements; ++j) {
           temp_reply = kvs_reply->element[j];
           if (temp_reply->type ==

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/cuckoo_hashtable_ops.py
@@ -14,9 +14,6 @@
 # ==============================================================================
 """CuckooHash Lookup operations."""
 # pylint: disable=g-bad-name
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import copy
 import functools
@@ -127,11 +124,6 @@ class CuckooHashTable(LookupInterface):
       )
       if not context.executing_eagerly():
         ops.add_to_collection(ops.GraphKeys.SAVEABLE_OBJECTS, self.saveable)
-    else:
-      if shard_saveable_object_fn:
-        self._saveable_fn = shard_saveable_object_fn
-      else:
-        self._saveable_fn = CuckooHashTable._Saveable
 
   def _create_resource(self):
     # The table must be shared if checkpointing is requested for multi-worker
@@ -440,15 +432,18 @@ class CuckooHashTable(LookupInterface):
     # full_name helps to figure out the name-based Saver's name for this saveable.
     full_name = self._table_name
     self._new_obj_trackable = None  # reset _new_obj_trackable when save again
-    return {
-        "table":
-            functools.partial(
-                self._saveable_fn,
-                table=self,
-                name=self._name,
-                full_name=full_name,
-            )
-    }
+    if self._checkpoint:
+      return {
+          "table":
+              functools.partial(
+                  self._saveable_fn,
+                  table=self,
+                  name=self._name,
+                  full_name=full_name,
+              )
+      }
+    else:
+      return {}
 
   class _Saveable(BaseSaverBuilder.SaveableObject):
     """SaveableObject implementation for CuckooHashTable."""


### PR DESCRIPTION
# Description

fix some core dump cases and make usage of CUDA streams more reasonable.
Including:
(1)Raise error when embedding dim in Redis server is not equal to the runtime setting dim.
(2)Checkpoint setting is inoperative when calling _gather_saveables_for_checkpoint.
(3)Remove unnecessary get_size calling, and modify table_ to a unique_ptr. And fix rehashing mechanism to make it no more unnecessary extend hash table when input keys are duplicated.
(4)Redis reply obj may be a nullptr caused memory access segmentfault.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works