### PR TITLE
[Feat] Compatible with Tensorflow later than version 2.11.0.

### DIFF
--- a/build_deps/tf_dependency/build_defs.bzl.tpl
+++ b/build_deps/tf_dependency/build_defs.bzl.tpl
@@ -2,6 +2,8 @@
 
 D_GLIBCXX_USE_CXX11_ABI = "%{tf_cx11_abi}"
 
+TF_CXX_STANDARD = "%{tf_cxx_standard}"
+
 DTF_VERSION_INTEGER = "%{tf_version_integer}"
 
 FOR_TF_SERVING = "%{for_tf_serving}"

--- a/build_deps/tf_dependency/tf_configure.bzl
+++ b/build_deps/tf_dependency/tf_configure.bzl
@@ -8,6 +8,8 @@ _TF_SHARED_LIBRARY_NAME = "TF_SHARED_LIBRARY_NAME"
 
 _TF_CXX11_ABI_FLAG = "TF_CXX11_ABI_FLAG"
 
+_TF_CXX_STANDARD = "TF_CXX_STANDARD"
+
 _FOR_TF_SERVING = "FOR_TF_SERVING"
 
 _TF_VERSION_INTEGER = "TF_VERSION_INTEGER"
@@ -208,6 +210,7 @@ def _tf_pip_impl(repository_ctx):
     tf_shared_library_name = repository_ctx.os.environ[_TF_SHARED_LIBRARY_NAME]
     tf_shared_library_path = "%s/%s" % (tf_shared_library_dir, tf_shared_library_name)
     tf_cx11_abi = "-D_GLIBCXX_USE_CXX11_ABI=%s" % (repository_ctx.os.environ[_TF_CXX11_ABI_FLAG])
+    tf_cxx_standard = "%s" % (repository_ctx.os.environ[_TF_CXX_STANDARD])
     tf_version_integer = "-DTF_VERSION_INTEGER=%s" % (repository_ctx.os.environ[_TF_VERSION_INTEGER])
     for_tf_serving = repository_ctx.os.environ[_FOR_TF_SERVING]
 
@@ -231,6 +234,7 @@ def _tf_pip_impl(repository_ctx):
         "build_defs.bzl",
         {
             "%{tf_cx11_abi}": tf_cx11_abi,
+            "%{tf_cxx_standard}": tf_cxx_standard,
             "%{tf_version_integer}": tf_version_integer,
             "%{for_tf_serving}": for_tf_serving,
         },
@@ -242,6 +246,7 @@ tf_configure = repository_rule(
         _TF_SHARED_LIBRARY_DIR,
         _TF_SHARED_LIBRARY_NAME,
         _TF_CXX11_ABI_FLAG,
+        _TF_CXX_STANDARD,
         _FOR_TF_SERVING,
     ],
     implementation = _tf_pip_impl,

--- a/build_deps/toolchains/gcc7_manylinux2010-nvcc-cuda11/clang/bin/crosstool_wrapper_driver_is_not_gcc
+++ b/build_deps/toolchains/gcc7_manylinux2010-nvcc-cuda11/clang/bin/crosstool_wrapper_driver_is_not_gcc
@@ -178,7 +178,7 @@ def InvokeNvcc(argv, log=False):
     undefines = ''.join([' -U' + define for define in undefines])
     std_options = GetOptionValue(argv, '-std')
     # Supported -std flags as of CUDA 9.0. Only keep last to mimic gcc/clang.
-    nvcc_allowed_std_options = ["c++03", "c++11", "c++14"]
+    nvcc_allowed_std_options = ["c++03", "c++11", "c++14", "c++17"]
     std_options = ''.join([' -std=' + define
                            for define in std_options if define in nvcc_allowed_std_options][-1:])
     fatbin_options = ''.join([' --fatbin-options=' + option

--- a/build_deps/toolchains/gpu/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
+++ b/build_deps/toolchains/gpu/crosstool/clang/bin/crosstool_wrapper_driver_is_not_gcc.tpl
@@ -167,7 +167,7 @@ def InvokeNvcc(argv, log=False):
   undefines = ''.join([' -U' + define for define in undefines])
   std_options = GetOptionValue(argv, 'std')
   # currently only c++14 is supported by Cuda 10.0 std argument
-  nvcc_allowed_std_options = ["c++14"]
+  nvcc_allowed_std_options = ["c++03", "c++11", "c++14", "c++17"]
   std_options = ''.join([' -std=' + define
       for define in std_options if define in nvcc_allowed_std_options])
 

--- a/build_deps/toolchains/gpu/cuda_configure.bzl
+++ b/build_deps/toolchains/gpu/cuda_configure.bzl
@@ -74,7 +74,7 @@ _DEFAULT_CUDA_COMPUTE_CAPABILITIES.update(
         "7.5",
         "8.0",
         "8.6",
-    ] for v in range(1, 8)},
+    ] for v in range(0, 8)},
 )
 
 _DEFAULT_CUDA_COMPUTE_CAPABILITIES.update(
@@ -86,7 +86,21 @@ _DEFAULT_CUDA_COMPUTE_CAPABILITIES.update(
         "8.0",
         "8.6",
         "8.9",
+        "9.0",
     ] for v in range(8, 9)},
+)
+
+_DEFAULT_CUDA_COMPUTE_CAPABILITIES.update(
+    {"12.{}".format(v): [
+        "6.0",
+        "6.1",
+        "7.0",
+        "7.5",
+        "8.0",
+        "8.6",
+        "8.9",
+        "9.0",
+    ] for v in range(0, 8)},
 )
 
 def _get_python_bin(repository_ctx):
@@ -562,10 +576,17 @@ def _find_cuda_lib(
         Returns the path to the library.
       """
     file_name = lib_name(lib, cpu_value, version, static)
+    paths = ["%s/%s" % (basedir, file_name)]
+    if version:
+        # In cuda 12.1, the name of libcupti.so is no longer libcupti.so.12.1 but libcupti.so.2023.1.0.
+        # And there is still reserve a libcupti.so.12 link, so we need to find it but not "*.12.1".
+        major_version = version.split(".")[0]
+        file_name_major = lib_name(lib, cpu_value, major_version, static)
+        paths.append("%s/%s" % (basedir, file_name_major))
 
     return find_lib(
         repository_ctx,
-        ["%s/%s" % (basedir, file_name)],
+        paths,
         check_soname = version and not static,
     )
 

--- a/build_deps/toolchains/redis/redis-plus-plus.BUILD
+++ b/build_deps/toolchains/redis/redis-plus-plus.BUILD
@@ -2,6 +2,7 @@ load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
 load(
     "@local_config_tf//:build_defs.bzl",
     "D_GLIBCXX_USE_CXX11_ABI",
+    "TF_CXX_STANDARD",
 )
 
 package(
@@ -30,8 +31,8 @@ cmake(
     generate_args = [
         "-DCMAKE_BUILD_TYPE=Release",
         "-DREDIS_PLUS_PLUS_BUILD_TEST=OFF",
-        "-DREDIS_PLUS_PLUS_CXX_STANDARD=11",
-        "-DCMAKE_CXX_FLAGS="+D_GLIBCXX_USE_CXX11_ABI,
+        "-DREDIS_PLUS_PLUS_CXX_STANDARD=" + TF_CXX_STANDARD.split("c++")[-1],
+        "-DCMAKE_CXX_FLAGS=" + D_GLIBCXX_USE_CXX11_ABI,
     ],
     lib_source = "@redis-plus-plus//:all_srcs",
     out_static_libs = ["libredis++.a"],

--- a/configure.py
+++ b/configure.py
@@ -219,6 +219,18 @@ def create_build_configuration():
   write_action_env("TF_SHARED_LIBRARY_DIR", get_tf_shared_lib_dir())
   write_action_env("TF_SHARED_LIBRARY_NAME", get_shared_lib_name())
   write_action_env("TF_CXX11_ABI_FLAG", tf.sysconfig.CXX11_ABI_FLAG)
+  tf_cxx_standard_compile_flags = [
+      flag for flag in tf.sysconfig.get_compile_flags() if "-std=" in flag
+  ]
+  if len(tf_cxx_standard_compile_flags) > 0:
+    tf_cxx_standard_compile_flag = tf_cxx_standard_compile_flags[-1]
+  else:
+    tf_cxx_standard_compile_flag = None
+  if tf_cxx_standard_compile_flag is None:
+    tf_cxx_standard = "c++14"
+  else:
+    tf_cxx_standard = tf_cxx_standard_compile_flag.split("-std=")[-1]
+  write_action_env("TF_CXX_STANDARD", tf_cxx_standard)
 
   tf_version_integer = get_tf_version_integer()
   # This is used to trace the difference between Tensorflow versions.

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/cuckoo_hashtable_op.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/cuckoo_hashtable_op.cc
@@ -219,7 +219,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     LaunchTensorsFind<CPUDevice, K, V> launcher(value_dim);
     launcher.launch(ctx, table_, key, value, default_value);
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status FindWithExists(OpKernelContext* ctx, const Tensor& key, Tensor* value,
@@ -229,7 +229,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     LaunchTensorsFindWithExists<CPUDevice, K, V> launcher(value_dim);
     launcher.launch(ctx, table_, key, value, default_value, exists);
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status DoInsert(bool clear, OpKernelContext* ctx, const Tensor& keys,
@@ -243,7 +243,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     LaunchTensorsInsert<CPUDevice, K, V> launcher(value_dim);
     launcher.launch(ctx, table_, keys, values);
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status DoAccum(bool clear, OpKernelContext* ctx, const Tensor& keys,
@@ -257,7 +257,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     LaunchTensorsAccum<CPUDevice, K, V> launcher(value_dim);
     launcher.launch(ctx, table_, keys, values_or_deltas, exists);
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status Insert(OpKernelContext* ctx, const Tensor& keys,
@@ -272,12 +272,12 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     for (int64 i = 0; i < key_flat.size(); ++i) {
       table_->erase(tensorflow::lookup::SubtleMustCopyIfIntegral(key_flat(i)));
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status Clear(OpKernelContext* ctx) {
     table_->clear();
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status Accum(OpKernelContext* ctx, const Tensor& keys,
@@ -304,7 +304,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     table_->dump((K*)keys->tensor_data().data(),
                  (V*)values->tensor_data().data(), 0, table_size);
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status SaveToFileSystemImpl(FileSystem* fs, const size_t value_dim,
@@ -319,7 +319,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     bool has_atomic_move = false;
     auto has_atomic_move_ret = fs->HasAtomicMove(filepath, &has_atomic_move);
     bool need_tmp_file =
-        (has_atomic_move == false) || (has_atomic_move_ret != Status::OK());
+        (has_atomic_move == false) || (has_atomic_move_ret != TFOkStatus);
     if (!need_tmp_file) {
       key_tmpfilepath = key_filepath;
       value_tmpfilepath = value_filepath;
@@ -387,7 +387,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
       TF_RETURN_IF_ERROR(fs->RenameFile(value_tmpfilepath, value_filepath));
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status SaveToFileSystem(OpKernelContext* ctx, const string& dirpath,
@@ -461,7 +461,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
     LOG(INFO) << "Finish loading " << key_size << " keys and values from "
               << key_filepath << " and " << value_filepath << " in total.";
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status LoadFromFileSystem(OpKernelContext* ctx, const string& dirpath,
@@ -500,7 +500,7 @@ class CuckooHashTableOfTensors final : public LookupInterface {
       string filepath = io::JoinPath(dirpath, file_name);
       return LoadFromFileSystemImpl(fs, value_dim, filepath, buffer_size);
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   DataType key_dtype() const override { return DataTypeToEnum<K>::v(); }
@@ -557,7 +557,7 @@ class HashTableOpKernel : public OpKernel {
       *container = h(0);
       *table_handle = h(1);
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status GetResourceHashTable(StringPiece input_name, OpKernelContext* ctx,

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/cuckoo_hashtable_op.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/cuckoo_hashtable_op.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/types.h"
+#include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h"
 
 namespace tensorflow {
 namespace recommenders_addons {
@@ -76,7 +77,7 @@ class HashTableOp : public OpKernel {
                                                      table_.AllocatedBytes());
           }
           *ret = container;
-          return Status::OK();
+          return TFOkStatus;
         };
 
     LookupInterface* table = nullptr;

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/cuckoo_hashtable_op_gpu.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/cuckoo_hashtable_op_gpu.h
@@ -30,6 +30,7 @@ limitations under the License.
 #include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/types.h"
+#include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h"
 
 namespace tensorflow {
 namespace recommenders_addons {
@@ -77,7 +78,7 @@ class HashTableGpuOp : public OpKernel {
                     container->MemoryUsed() + table_.AllocatedBytes());
               }
               *ret = container;
-              return Status::OK();
+              return TFOkStatus;
             };
 
     lookup::LookupInterface* table = nullptr;

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
@@ -130,7 +130,7 @@ class RedisWrapper<RedisInstance, K, V,
           }
           if (redis_conn_read != nullptr && redis_conn_write != nullptr) {
             this->isRedisConnect = true;
-            return Status::OK();
+            return TFOkStatus;
           }
         }
         LOG(WARNING) << "Can not access the host "
@@ -151,7 +151,7 @@ class RedisWrapper<RedisInstance, K, V,
         return Status(error::UNAVAILABLE, "Exit without any Redis connection.");
       }
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   static std::shared_ptr<RedisWrapper<RedisInstance, K, V>> get_instance() {
@@ -465,7 +465,7 @@ class RedisWrapper<RedisInstance, K, V,
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter>
@@ -568,7 +568,7 @@ class RedisWrapper<RedisInstance, K, V,
         }
       }
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status SetPersistBuckets(
@@ -594,7 +594,7 @@ class RedisWrapper<RedisInstance, K, V,
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   /*
@@ -604,7 +604,7 @@ class RedisWrapper<RedisInstance, K, V,
       const std::vector<std::string> &keys_prefix_name_slices,
       std::vector<aiocb> &wrs, const std::vector<int> &fds) override {
     if (fds.size() == 0) {
-      return Status::OK();
+      return TFOkStatus;
       ;
     }
 
@@ -667,7 +667,7 @@ class RedisWrapper<RedisInstance, K, V,
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status RestoreFromDisk(
@@ -675,7 +675,7 @@ class RedisWrapper<RedisInstance, K, V,
       std::vector<aiocb> &rds, const std::vector<int> &fds,
       const std::vector<unsigned long> &buf_sizes) override {
     if (fds.size() == 0) {
-      Status::OK();
+      return TFOkStatus;
     }
 
     // std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter> reply;
@@ -813,7 +813,7 @@ class RedisWrapper<RedisInstance, K, V,
     }
 
     return no_errors
-               ? Status::OK()
+               ? TFOkStatus
                : errors::Unknown("Unknown errors happen in file handles.");
   }
 
@@ -906,7 +906,7 @@ class RedisWrapper<RedisInstance, K, V,
       error_ptr = nullptr;
       return errors::Unknown(err.what());
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
  public:
@@ -1083,7 +1083,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status MgetToTensorWithExist(
@@ -1141,7 +1141,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status MsetCommand(
@@ -1228,7 +1228,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status MaccumCommand(
@@ -1325,7 +1325,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status DelCommand(
@@ -1404,7 +1404,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 };  // namespace redis_connection
 }  // namespace redis_connection

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_pool.hpp
@@ -192,7 +192,7 @@ class RedisWrapper<
         }
         if (redis_conn_read != nullptr && redis_conn_write != nullptr) {
           this->isRedisConnect = true;
-          return Status::OK();
+          return TFOkStatus;
         }
       }
       if (this->isRedisConnect == false) {
@@ -205,7 +205,7 @@ class RedisWrapper<
         return Status(error::UNAVAILABLE, "Exit without any Redis connection.");
       }
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   static std::shared_ptr<RedisWrapper<RedisInstance, K, V>> get_instance(
@@ -351,7 +351,7 @@ class RedisWrapper<
                  << keys_prefix_name_slice << " -- " << err.what();
       return errors::Unknown(err.what());
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter>
@@ -453,7 +453,7 @@ class RedisWrapper<
         }
       }
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status SetPersistBuckets(
@@ -478,7 +478,7 @@ class RedisWrapper<
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   /*
@@ -488,7 +488,7 @@ class RedisWrapper<
       const std::vector<std::string> &keys_prefix_name_slices,
       std::vector<aiocb> &wrs, const std::vector<int> &fds) override {
     if (fds.size() == 0) {
-      return Status::OK();
+      return TFOkStatus;
       ;
     }
 
@@ -551,7 +551,7 @@ class RedisWrapper<
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status RestoreFromDisk(
@@ -559,7 +559,7 @@ class RedisWrapper<
       std::vector<aiocb> &rds, const std::vector<int> &fds,
       const std::vector<unsigned long> &buf_sizes) override {
     if (fds.size() == 0) {
-      Status::OK();
+      return TFOkStatus;
     }
 
     // std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter> reply;
@@ -697,7 +697,7 @@ class RedisWrapper<
     }
 
     return no_errors
-               ? Status::OK()
+               ? TFOkStatus
                : errors::Unknown("Unknown errors happen in file handles.");
   }
 
@@ -790,7 +790,7 @@ class RedisWrapper<
       error_ptr = nullptr;
       return errors::Unknown(err.what());
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
  public:
@@ -936,7 +936,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status MgetToTensorWithExist(
@@ -984,7 +984,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       }
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status MsetCommand(
@@ -1058,7 +1058,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status MaccumCommand(
@@ -1141,7 +1141,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status DelCommand(
@@ -1199,7 +1199,7 @@ every bucket has its own BucketContext for sending data---for locating reply-
       return errors::Unknown(err.what());
     }
 
-    return Status::OK();
+    return TFOkStatus;
   }
 };  // namespace redis_connection
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
@@ -29,6 +29,7 @@ limitations under the License.
 #include "md5.h"
 #include "tensorflow/core/framework/tensor.h"
 #include "tensorflow/core/framework/types.h"
+#include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h"
 
 namespace tensorflow {
 namespace recommenders_addons {
@@ -381,7 +382,7 @@ class RedisBaseWrapper {
     } catch (const std::exception &err) {
       return errors::Unknown(err.what());
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   Status set_K_bucket_num_handle(KBucketNumHandle function) {
@@ -390,7 +391,7 @@ class RedisBaseWrapper {
     } catch (const std::exception &err) {
       return errors::Unknown(err.what());
     }
-    return Status::OK();
+    return TFOkStatus;
   }
 
   virtual Status Conn() = 0;

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
@@ -394,7 +394,7 @@ Status ParseJsonConfig(const std::string *const redis_config_abs_dir,
   json_value_free(config_value);
   free(file_contents);
 
-  return Status::OK();
+  return TFOkStatus;
 }
 
 extern "C" sds sdsempty(void);

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.h
@@ -37,6 +37,7 @@ limitations under the License.
 #include "tensorflow/core/platform/thread_annotations.h"
 #include "tensorflow/core/util/env_var.h"
 #include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/types.h"
+#include "tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h"
 
 namespace tensorflow {
 namespace recommenders_addons {
@@ -99,7 +100,7 @@ class HashTableOp : public OpKernel {
                                                      table_.AllocatedBytes());
           }
           *ret = container;
-          return Status::OK();
+          return TFOkStatus;
         };
 
     LookupInterface* table = nullptr;

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/cuckoo_hashtable_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/cuckoo_hashtable_ops.cc
@@ -39,7 +39,7 @@ Status ScalarAndTwoElementVectorInputsAndScalarOutputs(InferenceContext* c) {
   for (int i = 0; i < c->num_outputs(); ++i) {
     c->set_output(i, c->Scalar());
   }
-  return Status::OK();
+  return TFOkStatus;
 }
 
 }  // namespace
@@ -109,7 +109,7 @@ Status ValidateTableResourceHandle(InferenceContext* c, ShapeHandle keys,
                                         &output_shape_and_type->shape));
     }
   }
-  return Status::OK();
+  return TFOkStatus;
 }
 
 Status CuckooHashTableShape(InferenceContext* c, const ShapeHandle& key,
@@ -128,7 +128,7 @@ Status CuckooHashTableShape(InferenceContext* c, const ShapeHandle& key,
   c->set_output_handle_shapes_and_types(
       0, std::vector<ShapeAndType>{{key_s, key_t}, {value, value_t}});
 
-  return Status::OK();
+  return TFOkStatus;
 }
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableFind))
@@ -151,7 +151,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableFind))
           /*is_lookup=*/true, &value_shape_and_type));
       c->set_output(0, value_shape_and_type.shape);
 
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableFindWithExists))
@@ -177,7 +177,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableFindWithExists))
       c->set_output(0, value_shape_and_type.shape);
       c->set_output(1, keys);
 
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableInsert))
@@ -191,7 +191,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableInsert))
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
 
       // TODO: Validate keys and values shape.
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableAccum))
@@ -206,7 +206,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableAccum))
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
 
       // TODO: Validate keys and values shape.
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableRemove))
@@ -219,7 +219,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableRemove))
       TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(1), 1, &handle));
 
       // TODO(turboale): Validate keys shape.
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableClear))
@@ -251,7 +251,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableExport))
           /*is_lookup=*/false, &value_shape_and_type));
       c->set_output(0, keys);
       c->set_output(1, value_shape_and_type.shape);
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableSaveToFileSystem))
@@ -277,7 +277,7 @@ REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableImport))
       ShapeHandle keys;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &keys));
       TF_RETURN_IF_ERROR(c->Merge(keys, c->input(2), &keys));
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(CuckooHashTableLoadFromFileSystem))

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/math_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/math_ops.cc
@@ -49,7 +49,7 @@ Status SparseSegmentReductionShapeFn(InferenceContext* c) {
   TF_RETURN_IF_ERROR(
       c->Concatenate(c->Vector(InferenceContext::kUnknownDim), subshape, &out));
   c->set_output(0, out);
-  return Status::OK();
+  return TFOkStatus;
 }
 
 Status SparseSegmentReductionWithNumSegmentsShapeFn(InferenceContext* c) {
@@ -88,7 +88,7 @@ Status SparseSegmentReductionWithNumSegmentsShapeFn(InferenceContext* c) {
     TF_RETURN_IF_ERROR(c->Concatenate(c->Vector(dim0_value), subshape, &out));
   }
   c->set_output(0, out);
-  return Status::OK();
+  return TFOkStatus;
 }
 }  // namespace
 
@@ -153,7 +153,7 @@ REGISTER_OP("TfraSparseFillEmptyRows")
       c->set_output(1, output_values);
       c->set_output(2, empty_row_indicator);
       c->set_output(3, reverse_index_map);
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP("TfraSparseReshape")
@@ -173,7 +173,7 @@ REGISTER_OP("TfraSparseReshape")
 
       c->set_output(0, c->Matrix(c->Dim(indices, 0), c->Dim(new_shape, 0)));
       c->set_output(1, new_shape);
-      return Status::OK();
+      return TFOkStatus;
     });
 #endif  // GOOGLE_CUDA
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/redis_table_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/redis_table_ops.cc
@@ -39,7 +39,7 @@ Status ScalarAndTwoElementVectorInputsAndScalarOutputs(InferenceContext *c) {
   for (int i = 0; i < c->num_outputs(); ++i) {
     c->set_output(i, c->Scalar());
   }
-  return Status::OK();
+  return TFOkStatus;
 }
 
 }  // namespace
@@ -109,7 +109,7 @@ Status ValidateTableResourceHandle(InferenceContext *c, ShapeHandle keys,
                                         &output_shape_and_type->shape));
     }
   }
-  return Status::OK();
+  return TFOkStatus;
 }
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableFind))
@@ -132,7 +132,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableFind))
           /*is_lookup=*/true, &value_shape_and_type));
       c->set_output(0, value_shape_and_type.shape);
 
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableFindWithExists))
@@ -158,7 +158,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableFindWithExists))
       c->set_output(0, value_shape_and_type.shape);
       c->set_output(1, keys);
 
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableInsert))
@@ -172,7 +172,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableInsert))
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
 
       // TODO: Validate keys and values shape.
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableAccum))
@@ -187,7 +187,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableAccum))
       TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
 
       // TODO: Validate keys and values shape.
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableRemove))
@@ -200,7 +200,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableRemove))
       TF_RETURN_IF_ERROR(c->WithRankAtLeast(c->input(1), 1, &handle));
 
       // TODO(turboale): Validate keys shape.
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableClear))
@@ -232,7 +232,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableExport))
           /*is_lookup=*/false, &value_shape_and_type));
       c->set_output(0, keys);
       c->set_output(1, value_shape_and_type.shape);
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableSaveToFileSystem))
@@ -258,7 +258,7 @@ REGISTER_OP(PREFIX_OP_NAME(RedisTableImport))
       ShapeHandle keys;
       TF_RETURN_IF_ERROR(c->WithRank(c->input(1), 1, &keys));
       TF_RETURN_IF_ERROR(c->Merge(keys, c->input(2), &keys));
-      return Status::OK();
+      return TFOkStatus;
     });
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableLoadFromFileSystem))
@@ -287,7 +287,7 @@ Status RedisTableShape(InferenceContext *c, const ShapeHandle &key,
   c->set_output_handle_shapes_and_types(
       0, std::vector<ShapeAndType>{{key_s, key_t}, {value, value_t}});
 
-  return Status::OK();
+  return TFOkStatus;
 }
 
 REGISTER_OP(PREFIX_OP_NAME(RedisTableOfTensors))

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h
@@ -32,6 +32,13 @@ already used TFRA release 1 in product environment, and changing name to
 #define PREFIX_OP_NAME(N) CONCAT_TRIPLE_STRING(Tfr, a, N)
 #endif
 
+/* After TensorFlow version 2.10.0, "Status::OK()" upgraded to "OkStatus()".
+This code is for compatibility.*/
+#if TF_VERSION_INTEGER >= 2100
+#define TFOkStatus OkStatus()
+#else
+#define TFOkStatus Status::OK()
+#endif
 }  // namespace recommenders_addons
 }  // namespace tensorflow
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
@@ -441,7 +441,7 @@ class EmbeddingLookupTest(test.TestCase):
             params_nn = variable_scope.get_variable("n",
                                                     shape=[100, dim],
                                                     use_resource=False)
-            ids = script_ops.py_func(
+            ids = script_ops.py_func_common(
                 _create_dynamic_shape_tensor(min_val=0, max_val=100),
                 inp=[],
                 Tout=dtypes.int64,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/shadow_embedding_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/shadow_embedding_ops_test.py
@@ -455,10 +455,15 @@ class ShadowVariableBasicBehaviorTest(test.TestCase):
     self.assertAllClose(values, dense_params)
 
     sparse_slot_params = sparse_params.get_slot_variables(sparse_optimizer)
-    dense_slot_params = [
-        dense_optimizer.get_slot(dense_params, name)
-        for name in dense_optimizer.get_slot_names()
-    ]
+    if hasattr(dense_optimizer, 'get_slot_names'):
+      dense_slot_params = [
+          dense_optimizer.get_slot(dense_params, name)
+          for name in dense_optimizer.get_slot_names()
+      ]
+    else:
+      dense_slot_params = [
+          s for s in dense_optimizer._variables if 'iteration' not in s.name
+      ]
 
     for i in range(len(sparse_slot_params)):
       sparse_values = sparse_slot_params[i].lookup(ids)
@@ -505,10 +510,15 @@ class ShadowVariableBasicBehaviorTest(test.TestCase):
     self.assertAllClose(values, dense_params, rtol, atol)
 
     sparse_slot_params = sparse_params.get_slot_variables(sparse_optimizer)
-    dense_slot_params = [
-        dense_optimizer.get_slot(dense_params, name)
-        for name in dense_optimizer.get_slot_names()
-    ]
+    if hasattr(dense_optimizer, 'get_slot_names'):
+      dense_slot_params = [
+          dense_optimizer.get_slot(dense_params, name)
+          for name in dense_optimizer.get_slot_names()
+      ]
+    else:
+      dense_slot_params = [
+          s for s in dense_optimizer._variables if 'iteration' not in s.name
+      ]
 
     for i in range(len(sparse_slot_params)):
       sparse_values = sparse_slot_params[i].lookup(ids)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -46,7 +46,10 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import sparse_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.ops import variable_scope
-from tensorflow.python.training.tracking import base as trackable
+try:  # tf version >= 2.10.0
+  from tensorflow.python.trackable import base as trackable
+except:
+  from tensorflow.python.training.tracking import base as trackable
 from tensorflow.python.training.tracking import data_structures
 from tensorflow.python.util import compat
 from tensorflow.python.util.tf_export import tf_export

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/shadow_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/shadow_embedding_ops.py
@@ -50,7 +50,10 @@ from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import gen_resource_variable_ops
 from tensorflow.python.ops import resource_variable_ops
-from tensorflow.python.training.tracking import base as trackable
+try:  # tf version >= 2.10.0
+  from tensorflow.python.trackable import base as trackable
+except:
+  from tensorflow.python.training.tracking import base as trackable
 
 
 class ShadowVariable(de.TrainableWrapper):

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -57,11 +57,14 @@ from tensorflow.python.platform import tf_logging
 from tensorflow.python.training import device_setter
 from tensorflow.python.training import optimizer
 from tensorflow.python.training import slot_creator
-from tensorflow.python.training.tracking import base
+try:  # tf version >= 2.10.0
+  from tensorflow.python.checkpoint import restore as ckpt_base
+except:
+  from tensorflow.python.training.tracking import base as ckpt_base
 
 _PARTITION_SHAPE = 'partition_shape'
 
-tf_checkpoint_position_bind_object = base.CheckpointPosition.bind_object
+tf_checkpoint_position_bind_object = ckpt_base.CheckpointPosition.bind_object
 
 
 class _DenseDynamicEmbeddingTrainableProcessor(optimizer._OptimizableVariable):
@@ -384,4 +387,4 @@ def patch_on_tf():
     kinit_tf.VarianceScaling.__call__ = __call__for_keras_init_v2
   if kinit_K is not None:
     kinit_K.VarianceScaling.__call__ = __call__for_keras_init_v2
-  base.CheckpointPosition.bind_object = bind_object
+  ckpt_base.CheckpointPosition.bind_object = bind_object

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/warm_start_util.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/warm_start_util.py
@@ -127,7 +127,11 @@ def warm_start(ckpt_to_initialize_from,
     else:
       prev_var_name = var_name
 
-    saveables = saveable_object_util.validate_and_slice_inputs([variable])
+    try:
+      saveables = saveable_object_util.validate_and_slice_inputs([variable])
+    except AttributeError:
+      saveables_dict = saveable_object_util.op_list_to_dict([variable])
+      saveables = saveable_object_util.validate_and_slice_inputs(saveables_dict)
     for saveable in saveables:
       restore_specs = []
       for spec in saveable.specs:

--- a/tensorflow_recommenders_addons/embedding_variable/core/kernels/ev_ops.cc
+++ b/tensorflow_recommenders_addons/embedding_variable/core/kernels/ev_ops.cc
@@ -560,7 +560,7 @@ class EVExportOp : public OpKernel {
                                   &val));
     auto key_flat = key->flat<TKey>();
     auto val_matrix = val->matrix<TValue>();
-    for (size_t i = 0; i < total_size; ++i) {
+    for (int64_t i = 0; i < total_size; ++i) {
       key_flat(i) = key_list[i];
       TValue* value = valueptr_list[i];
       Eigen::array<Eigen::DenseIndex, 1> dims({ev->ValueLen()});
@@ -600,7 +600,7 @@ class EVImportOp : public OpKernel {
     Tensor val = ctx->input(2);
     auto key_flat = key.flat<TKey>();
     auto val_matrix = val.matrix<TValue>();
-    for (size_t i = 0; i < key.NumElements(); ++i) {
+    for (int64_t i = 0; i < key.NumElements(); ++i) {
       auto value = &val_matrix(i, 0);
       ev->LookupOrCreate(key_flat(i), value);
     }

--- a/tensorflow_recommenders_addons/embedding_variable/python/ops/embedding_variable_ops.py
+++ b/tensorflow_recommenders_addons/embedding_variable/python/ops/embedding_variable_ops.py
@@ -35,7 +35,10 @@ from tensorflow.python.ops import gen_array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.ops import resource_variable_ops
-from tensorflow.python.training.tracking import base as trackable
+try:  # tf version >= 2.10.0
+  from tensorflow.python.trackable import base as trackable
+except:
+  from tensorflow.python.training.tracking import base as trackable
 from tensorflow.python.util import compat
 from tensorflow.python.training.saving import saveable_object
 from tensorflow.python.training.saver import BaseSaverBuilder

--- a/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
+++ b/tensorflow_recommenders_addons/tensorflow_recommenders_addons.bzl
@@ -3,6 +3,7 @@ load(
     "DTF_VERSION_INTEGER",
     "D_GLIBCXX_USE_CXX11_ABI",
     "FOR_TF_SERVING",
+    "TF_CXX_STANDARD",
 )
 load(
     "@local_config_cuda//cuda:build_defs.bzl",
@@ -46,11 +47,11 @@ def custom_op_library(
         "//conditions:default": [
             "-pthread",
             "-funroll-loops",
-            "-std=c++14",
             D_GLIBCXX_USE_CXX11_ABI,
             DTF_VERSION_INTEGER,
         ],
     })
+    copts = copts + ["-std=" + TF_CXX_STANDARD]
 
     if cuda_srcs:
         copts = copts + if_cuda(["-DGOOGLE_CUDA=1"])
@@ -58,7 +59,6 @@ def custom_op_library(
             "-x cuda",
             "-nvcc_options=relaxed-constexpr",
             "-nvcc_options=ftz=true",
-            "-std=c++14",
         ])
         cuda_deps = deps + if_cuda_is_configured(cuda_deps) + if_cuda_is_configured([
             "@local_config_cuda//cuda:cuda_headers",

--- a/tensorflow_recommenders_addons/utils/resource_loader.py
+++ b/tensorflow_recommenders_addons/utils/resource_loader.py
@@ -26,7 +26,7 @@ SKIP_CUSTOM_OPS = False
 def get_required_tf_version():
   try:
     pkg = pkg_resources.get_distribution("tensorflow-recommenders-addons")
-  except pkg_resources.DistributionNotFound:
+  except:
     try:
       pkg = pkg_resources.get_distribution("tensorflow-recommenders-addons-gpu")
     except pkg_resources.DistributionNotFound:


### PR DESCRIPTION
# Description

Brief Description of the PR:

Compatibility update. Now TFRA is compatible with Tensorflow later than version 2.11.0 and pass all CI test in the NCG container tensorflow:23.04-tf2-py3. 
It also supports automatic detection of TF compile cxx standard versions. 

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Run all test script under TF 2.11+
