### PR TITLE
[fix] fcntl.flock didn't work properly when MPI training, remove them to fix json loading bug

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/redis_table_ops.py
@@ -210,19 +210,6 @@ class RedisTable(LookupInterface):
         f0.write(
             json.dumps(self.default_redis_params, indent=2, ensure_ascii=True))
         fcntl.flock(f0, fcntl.LOCK_UN)
-    else:
-      with open(self._config.redis_config_abs_dir, 'r', encoding='utf-8') as f0:
-        fcntl.flock(f0, fcntl.LOCK_EX)
-        params_load = json.load(f0)
-        fcntl.flock(f0, fcntl.LOCK_UN)
-        self._redis_params = self.default_redis_params.copy()
-        for k in self._redis_params.keys():
-          if k in params_load:
-            self._redis_params[k] = params_load[k]
-      with open(self._config.redis_config_abs_dir, 'w', encoding='utf-8') as f1:
-        fcntl.flock(f1, fcntl.LOCK_EX)
-        f1.write(json.dumps(self._redis_params, indent=2, ensure_ascii=True))
-        fcntl.flock(f1, fcntl.LOCK_UN)
 
     self._shared_name = None
     if context.executing_eagerly():


### PR DESCRIPTION
# Description

Fix json loading bug when training  with MPI or Horovod.
error is `json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)`

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
