### PR TITLE
[Refactor]removed a build warning

### DIFF
--- a/build_deps/tf_dependency/tf_configure.bzl
+++ b/build_deps/tf_dependency/tf_configure.bzl
@@ -218,7 +218,7 @@ def _tf_pip_impl(repository_ctx):
         repository_ctx,
         None,
         "",
-        tf_shared_library_name,
+        "libtensorflow_framework.so",
         [tf_shared_library_path],
         [tf_shared_library_name],
     )


### PR DESCRIPTION
removed a build warning
`WARNING: /root/.cache/bazel/_bazel_root/24ead6407f1760803002dd5e0943eb24/external/local_config_tf/BUILD:13349:8: target 'libtensorflow_framework.so.2' is both a rule and a file; please choose another name for the rule`