### PR TITLE
[CICD]Enhance project's compatibility

### DIFF
--- a/.github/workflows/make_wheel_Linux_x86.sh
+++ b/.github/workflows/make_wheel_Linux_x86.sh
@@ -11,7 +11,8 @@ else
   export TF_NAME='tensorflow'
 fi
 
-if [ $TF_VERSION == "2.6.3" ]  || [ $TF_VERSION == "2.8.3" ] ; then
+# if tensorflow version >= 2.6.0 and <= 2.11.9
+if [[ "$TF_VERSION" =~ ^2\.([6-9]|10|11)\.[0-9]$ ]] ; then
   export BUILD_IMAGE="tfra/nosla-cuda11.2.1-cudnn8-ubuntu20.04-manylinux2014-python$PY_VERSION"
   export TF_CUDA_VERSION="11.2"
   export TF_CUDNN_VERSION="8.1"

--- a/.github/workflows/make_wheel_macOS_arm64.sh
+++ b/.github/workflows/make_wheel_macOS_arm64.sh
@@ -2,13 +2,37 @@
 #
 # Making wheel for macOS arm64 architecture
 # Requirements: 
-# MacOS Monterey 12.0.0 +, Tensorflow-macos 2.6.0 or 2.8.0, ARM64 Apple Silicon, Bazel 4.1.0 +
+# MacOS Monterey 12.0.0 +, Tensorflow-macos 2.6.0 - 2.11.0, ARM64 Apple Silicon, Bazel 5.1.1
 # Please don't install tensorflow-metal, it may cause incorrect GPU devices detection issue.
 set -e -x
 
+export TF_NEED_CUDA=0
+if [ -z $HOROVOD_VERSION ] ; then
+  export HOROVOD_VERSION='0.28.1'
+fi
+
+# For TensorFlow version 2.12 or earlier:
+export PROTOBUF_VERSION=3.19.6
+export TF_NAME="tensorflow-macos"
+
 python --version
+python -m pip install --default-timeout=1000 delocate==0.10.3 wheel setuptools
+# For TensorFlow version 2.13 or later:
+if [[ "$TF_VERSION" =~ ^2\.1[3-9]\.[0-9]$ ]] ; then
+  export PROTOBUF_VERSION=3.20.3
+  export TF_NAME="tensorflow"
+fi
+
+python -m pip install \
+  --platform=macosx_12_0_arm64 \
+  --target=$(python -c 'import site; print(site.getsitepackages()[0])') \
+  --upgrade \
+  --only-binary=:all: \
+  protobuf~=$PROTOBUF_VERSION $TF_NAME==$TF_VERSION
 
 python configure.py
+# Setting DYLD_LIBRARY_PATH to help delocate finding tensorflow after the rpath invalidation
+export DYLD_LIBRARY_PATH=$DYLD_LIBRARY_PATH:$(python -c 'import configure; print(configure.get_tf_shared_lib_dir())')
 
 bazel build \
   --cpu=darwin_arm64 \
@@ -20,5 +44,5 @@ bazel build \
   --test_output=errors \
   build_pip_pkg
 
-# Output the wheel file to the artifacts directory
-bazel-bin/build_pip_pkg artifacts $NIGHTLY_FLAG
+bazel-bin/build_pip_pkg artifacts "--plat-name macosx_11_0_arm64 $NIGHTLY_FLAG"
+delocate-wheel -w wheelhouse -v --ignore-missing-dependencies artifacts/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ on:
 
 env:
   MIN_PY_VERSION: '3.7'
-  MAX_PY_VERSION: '3.9'
+  MAX_PY_VERSION: '3.10'
   HOROVOD_VERSION: '0.23.0'
 
 jobs:
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
-          python-version: ${{ env.MIN_PY_VERSION }}
+          python-version: ${{ env.MAX_PY_VERSION }}
       - name: Build wheels
         run: |
-          pip install --default-timeout=1000 -r tools/install_deps/pytest.txt -r tools/install_deps/tensorflow-cpu.txt -r requirements.txt
+          pip install --default-timeout=1000 -r tools/install_deps/pytest.txt -r tools/install_deps/tensorflow.txt -r requirements.txt
           sudo apt install -y redis > /dev/null 2> /dev/null
           bash tools/install_deps/install_bazelisk.sh ./
           python -m pip install tensorflow-io
@@ -39,29 +39,22 @@ jobs:
           bazel test --local_ram_resources=4096 -c opt -k --test_timeout 300,450,1200,3600 --test_output=errors //tensorflow_recommenders_addons/...
   release-wheel:
     name: Build release wheels
-    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # TODO: add back 'windows-latest' when it can be compiled.
         os: ['macos-12', 'ubuntu-20.04']
-        py-version: ['3.7', '3.8', '3.9']
-        tf-version: ['2.6.3', '2.8.3']
-        tf-need-cuda: ['1', '0']
+        py-version: ['3.7', '3.8', '3.9', '3.10']
+        tf-version: ['2.8.3', '2.11.0']
+        tf-need-cuda: ['0', '1']
         tf-cuda-version: ['11.2']
         tf-cudnn-version: ['8.1']
         cpu: ['x86']
-#       TODO(poinwater): add macOS CI once GitHub supports macOS 12.0.0 + 
-#        include:
-#          - os: 'macos-11'
-#            cpu: 'arm64'
-#            tf-version: '2.5.0'
-#            py-version: '3.9'
-#            tf-need-cuda: '0'
         exclude:
           # excludes cuda on macOS
           - os: 'macos-12'
             tf-need-cuda: '1'
       fail-fast: false
+    runs-on: ${{ matrix.os }}
     steps:
       - name: clear cache folder
         run: rm -rf /usr/share/dotnet /opt/ghc "/usr/local/share/boost"
@@ -72,11 +65,14 @@ jobs:
           script: |
             const commit_details = await github.git.getCommit({owner: context.repo.owner, repo: context.repo.repo, commit_sha: context.sha});
             return commit_details.data.author.date
+      - if: matrix.tf-version != '2.11.0'
+        shell: bash
+        run: echo "SKIP_CUSTOM_OP_TESTS=--skip-custom-ops" >> $GITHUB_ENV
       - if: github.event_name == 'push'
         shell: bash
         run: echo "NIGHTLY_FLAG=--nightly" >> $GITHUB_ENV
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.py-version }}
       - name: Setup Bazel
@@ -94,7 +90,11 @@ jobs:
           NIGHTLY_TIME: ${{ steps.author-date.outputs.result }}
           CPU: ${{ matrix.cpu }}
         shell: bash
-        run: bash .github/workflows/make_wheel_${OS}_${CPU}.sh
+        run: |
+          if [[ "$TF_VERSION" =~ ^2\.(9|10|11)\.[0-9]$ ]] ; then
+            export HOROVOD_VERSION="0.28.1"
+          fi
+          bash .github/workflows/make_wheel_${OS}_${CPU}.sh
       - uses: haya14busa/action-cond@v1
         id: device
         with:
@@ -113,17 +113,9 @@ jobs:
       matrix:
         # TODO: add back 'Windows' when it can be compiled.
         os: ['macOS', 'Linux']
-        py-version: ['3.7', '3.8', '3.9']
-        tf-version: ['2.8.3']
-        tf-need-cuda: ['1', '0']
+        py-version: ['3.7', '3.8', '3.9', '3.10']
+        tf-need-cuda: ['0', '1']
         cpu: ['x86']
-#       TODO(poinwater): add macOS CI once GitHub supports macOS 12.0.0 + 
-#        include:
-#          - os: 'macOS'
-#            cpu: 'arm64'
-#            tf-version: '2.5.0'
-#            py-version: '3.9'
-#            tf-need-cuda: '0'
         exclude:
           # excludes cuda on macOS
           - os: 'macOS'
@@ -155,7 +147,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        py-version: ['3.7', '3.8', '3.9']
+        py-version: ['3.7', '3.8', '3.9', '3.10']
     if: (github.event_name == 'push' && github.ref == 'refs/heads/master')
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -192,36 +192,26 @@ pip install artifacts/tensorflow_recommenders_addons_gpu-*.whl
 Requirements:
 
 - macOS 12.0.0+
-- Python 3.8 or 3.9
-- tensorflow-macos 2.6.0
-- bazel 4.1.0+
+- Python 3.9
+- tensorflow-macos 2.9.0
+- bazel 5.1.1
 
 The natively supported TensorFlow is maintained by Apple. Please see the instruction [Get started with tensorflow-metal](https://developer.apple.com/metal/tensorflow-plugin/) to install the Tensorflow on apple silicon devices.
 
-
-```sh
-# Install TensorFlow macOS dependencies
-conda install -c apple tensorflow-deps==2.6.0
-
-# Install base TensorFlow
-python -m pip install tensorflow-macos==2.6.0
-```
-
-If you see any issue with installing `tensorflow-macos`, please contact the [Apple Developer Forums: tensorflow-metal](https://developer.apple.com/forums/tags/tensorflow-metal) for help.
 
 **Install TFRA on Apple Silicon via PIP**
 ```sh
 python -m pip install tensorflow-recommenders-addons --no-deps
 ```
 
-**Install TFRA on Apple Silicon from Source**
+**Build TFRA on Apple Silicon from Source**
 
 ```sh
-export TF_VERSION="2.6.0"  # Specify your Tensorflow version here, 2.8.0 is well tested.
-export PY_VERSION="3.8"    # Specify your python version here, "3.9" is well tested.
+# Install bazelisk
+brew install bazelisk
 
-# Building TFRA wheel
-PY_VERSION=$PY_VERSION TF_VERSION=$TF_VERSION TF_NEED_CUDA="0" sh .github/workflows/make_wheel_macOS_arm64.sh
+# Build wheel from source
+PY_VERSION=3.9.0 TF_VERSION=2.9.0 TF_NEED_CUDA="0" sh .github/workflows/make_wheel_macOS_arm64.sh
 
 # Install the wheel
 python -m pip install --no-deps ./artifacts/*.whl

--- a/demo/dynamic_embedding/amazon-video-games-keras-eager/main.py
+++ b/demo/dynamic_embedding/amazon-video-games-keras-eager/main.py
@@ -3,6 +3,10 @@ import video_game_model
 import tensorflow as tf
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
+try:
+  from tensorflow.keras.optimizers.legacy import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 from absl import flags
 from absl import app
@@ -29,7 +33,7 @@ def train(num_steps):
   # Create a model
   model = video_game_model.VideoGameDnn(batch_size=FLAGS.batch_size,
                                         embedding_size=FLAGS.embedding_size)
-  optimizer = tf.keras.optimizers.Adam(1E-3, clipnorm=None)
+  optimizer = Adam(1E-3, clipnorm=None)
   optimizer = de.DynamicEmbeddingOptimizer(optimizer)
   auc = tf.keras.metrics.AUC(num_thresholds=1000)
   accuracy = tf.keras.metrics.BinaryAccuracy(dtype=tf.float32)

--- a/demo/dynamic_embedding/movielens-1m-keras-ps/movielens-1m-keras-ps.py
+++ b/demo/dynamic_embedding/movielens-1m-keras-ps/movielens-1m-keras-ps.py
@@ -5,6 +5,10 @@ import tensorflow_datasets as tfds
 from absl import flags
 from absl import app
 from tensorflow_recommenders_addons import dynamic_embedding as de
+try:
+  from tensorflow.keras.optimizers.legacy import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 flags = tf.compat.v1.app.flags
 FLAGS = flags.FLAGS
@@ -141,7 +145,7 @@ class Runner():
       model = DualChannelsDeepModel(
           self.ps_devices, self.embedding_size, self.embedding_size,
           tf.keras.initializers.RandomNormal(0.0, 0.5))
-      optimizer = tf.keras.optimizers.Adam(1E-3)
+      optimizer = Adam(1E-3)
       optimizer = de.DynamicEmbeddingOptimizer(optimizer)
 
       auc = tf.keras.metrics.AUC(num_thresholds=1000)

--- a/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
+++ b/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
@@ -6,6 +6,10 @@ import tensorflow_datasets as tfds
 from absl import flags
 from absl import app
 from tensorflow_recommenders_addons import dynamic_embedding as de
+try:
+  from tensorflow.keras.legacy.optimizers import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 os.environ["TF_FORCE_GPU_ALLOW_GROWTH"] = "true"  #VERY IMPORTANT!
 
@@ -537,7 +541,7 @@ def train():
   model = DualChannelsDeepModel(FLAGS.embedding_size, FLAGS.embedding_size,
                                 tf.keras.initializers.RandomNormal(0.0, 0.5),
                                 hvd.size(), hvd.rank())
-  optimizer = tf.keras.optimizers.Adam(1E-3)
+  optimizer = Adam(1E-3)
   optimizer = de.DynamicEmbeddingOptimizer(optimizer)
 
   auc = tf.keras.metrics.AUC(num_thresholds=1000)

--- a/demo/dynamic_embedding/movielens-1m-keras/movielens-1m-keras.py
+++ b/demo/dynamic_embedding/movielens-1m-keras/movielens-1m-keras.py
@@ -5,6 +5,10 @@ import tensorflow_datasets as tfds
 from absl import flags
 from absl import app
 from tensorflow_recommenders_addons import dynamic_embedding as de
+try:
+  from tensorflow.keras.legacy.optimizers import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 flags.DEFINE_string('mode', 'train', 'Select the running mode: train or test.')
 flags.DEFINE_string('model_dir', 'model_dir',
@@ -115,7 +119,7 @@ def train():
   dataset = get_dataset(batch_size=32)
   model = DualChannelsDeepModel(FLAGS.embedding_size, FLAGS.embedding_size,
                                 tf.keras.initializers.RandomNormal(0.0, 0.5))
-  optimizer = tf.keras.optimizers.Adam(1E-3)
+  optimizer = Adam(1E-3)
   optimizer = de.DynamicEmbeddingOptimizer(optimizer)
 
   auc = tf.keras.metrics.AUC(num_thresholds=1000)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
@@ -34,7 +34,10 @@ from tensorflow.python.distribute import values_util
 from tensorflow.python.framework import ops
 from tensorflow.python.eager import tape
 from tensorflow.python.ops.variables import VariableAggregation
-from tensorflow.python.training.tracking import data_structures
+try:  # The data_structures has been moved to the new package in tf 2.11
+  from tensorflow.python.trackable import data_structures
+except:
+  from tensorflow.python.training.tracking import data_structures
 
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import DistributedVariableWrapper, TrainableWrapperDistributedPolicy
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import make_partition

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding_test.py
@@ -38,6 +38,10 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 from tensorflow.python.training import adam
+try:
+  from tensorflow.keras.optimizers.legacy import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 tf.config.set_soft_device_placement(True)
 
@@ -162,7 +166,7 @@ class EmbeddingLayerTest(test.TestCase):
                                  initializer=init,
                                  bp_v2=False,
                                  name='iu702')
-    optmz = tf.keras.optimizers.Adam(learning_rate=1E-4, amsgrad=True)
+    optmz = Adam(learning_rate=1E-4, amsgrad=True)
     optmz = de.DynamicEmbeddingOptimizer(optmz)
     emb_layer = model.layers[0]
     model.compile(optimizer=optmz, loss='binary_crossentropy')
@@ -193,7 +197,7 @@ class EmbeddingLayerTest(test.TestCase):
           name='test_keras_save_restore',
       )(input_tensor)
       model = tf.keras.Model(inputs=input_tensor, outputs=embedding_out)
-      optimizer = tf.keras.optimizers.Adam(learning_rate=1E-4, amsgrad=False)
+      optimizer = Adam(learning_rate=1E-4, amsgrad=False)
       optimizer = de.DynamicEmbeddingOptimizer(optimizer)
       model.compile(optimizer=optimizer)
       return model
@@ -256,7 +260,7 @@ class EmbeddingLayerTest(test.TestCase):
           name='test_keras_save_restore_normal')(input_tensor)
       concat = tf.concat([embedding_out, normal_embedding_out], axis=0)
       model = tf.keras.Model(inputs=input_tensor, outputs=concat)
-      optimizer = tf.keras.optimizers.Adam(learning_rate=1E-4, amsgrad=False)
+      optimizer = Adam(learning_rate=1E-4, amsgrad=False)
       optimizer = de.DynamicEmbeddingOptimizer(optimizer)
       model.compile(optimizer=optimizer)
       return model
@@ -360,7 +364,7 @@ class EmbeddingLayerTest(test.TestCase):
           name='test_keras_save_restore_normal')(input_tensor)
       concat = tf.concat([embedding_out, normal_embedding_out], axis=0)
       model = tf.keras.Model(inputs=input_tensor, outputs=concat)
-      optimizer = tf.keras.optimizers.Adam(learning_rate=1E-4, amsgrad=False)
+      optimizer = Adam(learning_rate=1E-4, amsgrad=False)
       optimizer = de.DynamicEmbeddingOptimizer(optimizer)
       model.compile(optimizer=optimizer)
       return model
@@ -756,7 +760,7 @@ class FieldWiseEmbeddingLayerTest(test.TestCase):
                                  bp_v2=True,
                                  initializer=init,
                                  name='oe423')
-    optmz = tf.keras.optimizers.Adam(learning_rate=1E-4, amsgrad=True)
+    optmz = Adam(learning_rate=1E-4, amsgrad=True)
     optmz = de.DynamicEmbeddingOptimizer(optmz)
     emb_layer = model.layers[0]
     model.compile(optimizer=optmz, loss='binary_crossentropy')
@@ -786,7 +790,7 @@ class FieldWiseEmbeddingLayerTest(test.TestCase):
                                  bp_v2=False,
                                  initializer=init,
                                  name='pc053')
-    optmz = tf.keras.optimizers.Adam(learning_rate=1E-2, amsgrad=True)
+    optmz = Adam(learning_rate=1E-2, amsgrad=True)
     optmz = de.DynamicEmbeddingOptimizer(optmz)
     emb_layer = model.layers[0]
     model.compile(optimizer=optmz, loss='binary_crossentropy')
@@ -863,7 +867,7 @@ class FieldWiseEmbeddingLayerTest(test.TestCase):
 
     model = MyModel()
 
-    optmz = tf.keras.optimizers.Adam(1E-3)
+    optmz = Adam(1E-3)
     optmz = de.DynamicEmbeddingOptimizer(optmz)
     model.compile(optimizer=optmz, loss='binary_crossentropy')
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
@@ -58,6 +58,10 @@ from tensorflow.python.platform import test
 from tensorflow.python.training import device_setter
 from tensorflow.python.training import server_lib
 from tensorflow.python.util import compat
+try:
+  from tensorflow.keras.legacy.optimizers import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 
 # pylint: disable=missing-class-docstring
@@ -1346,7 +1350,7 @@ class EmbeddingLookupEagerTest(test.TestCase):
 
     def sorted_dynamic_embedding_value():
       embedding_var = devar
-      optimizer = tf.keras.optimizers.Adam(1E-3)
+      optimizer = Adam(1E-3)
       optimizer = de.DynamicEmbeddingOptimizer(optimizer)
 
       def var_fn():
@@ -1361,7 +1365,7 @@ class EmbeddingLookupEagerTest(test.TestCase):
 
     def sorted_static_embedding_value():
       embedding_var = tfvar
-      optimizer = tf.keras.optimizers.Adam(1E-3)
+      optimizer = Adam(1E-3)
       optimizer = de.DynamicEmbeddingOptimizer(optimizer)
 
       def var_fn():

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_variable_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_variable_test.py
@@ -57,11 +57,15 @@ from tensorflow.python.training import adam
 from tensorflow.python.training import saver
 from tensorflow.python.training import server_lib
 from tensorflow.python.training import training
-from tensorflow.python.training.tracking import data_structures
 from tensorflow.python.training.tracking import util as track_util
 from tensorflow.python.util import compat
 from tensorflow_estimator.python.estimator import estimator
 from tensorflow_estimator.python.estimator import estimator_lib
+
+try:  # The data_structures has been moved to the new package in tf 2.11
+  from tensorflow.python.trackable import data_structures
+except:
+  from tensorflow.python.training.tracking import data_structures
 
 try:
   import tensorflow_io

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/shadow_embedding_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/shadow_embedding_ops_test.py
@@ -42,6 +42,10 @@ from tensorflow.python.ops import variables
 from tensorflow.python.platform import test
 from tensorflow.python.training import adam
 from tensorflow.python.training import server_lib
+try:
+  from tensorflow.keras.legacy.optimizers import Adam
+except:
+  from tensorflow.keras.optimizers import Adam
 
 
 def _get_sparse_variable(name,
@@ -431,9 +435,9 @@ class ShadowVariableBasicBehaviorTest(test.TestCase):
     dense_params = variables.Variable([[1., 1.], [2., 2.], [3., 3.]],
                                       dtype=dtypes.float32)
 
-    sparse_optimizer = tf.keras.optimizers.Adam(1E-3)
+    sparse_optimizer = Adam(1E-3)
     sparse_optimizer = de.DynamicEmbeddingOptimizer(sparse_optimizer)
-    dense_optimizer = tf.keras.optimizers.Adam(1E-3)
+    dense_optimizer = Adam(1E-3)
     dense_optimizer = de.DynamicEmbeddingOptimizer(dense_optimizer)
 
     def sparse_loss():
@@ -483,9 +487,9 @@ class ShadowVariableBasicBehaviorTest(test.TestCase):
     dense_params = variables.Variable([[2.4, 3.1], [5.1, -0.7], [-15.2, 3.9]],
                                       dtype=dtypes.float32)
 
-    sparse_optimizer = tf.keras.optimizers.Adam(1E-4)
+    sparse_optimizer = Adam(1E-4)
     sparse_optimizer = de.DynamicEmbeddingOptimizer(sparse_optimizer)
-    dense_optimizer = tf.keras.optimizers.Adam(1E-4)
+    dense_optimizer = Adam(1E-4)
     dense_optimizer = de.DynamicEmbeddingOptimizer(dense_optimizer)
 
     rtol = 2e-4

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -46,7 +46,10 @@ try:  # tf version >= 2.10.0
   from tensorflow.python.trackable import base as trackable
 except:
   from tensorflow.python.training.tracking import base as trackable
-from tensorflow.python.training.tracking import data_structures
+try:  # The data_structures has been moved to the new package in tf 2.11
+  from tensorflow.python.trackable import data_structures
+except:
+  from tensorflow.python.training.tracking import data_structures
 from tensorflow.python.util import compat
 from tensorflow.python.util.tf_export import tf_export
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -60,7 +60,10 @@ from tensorflow.python.eager import tape
 from tensorflow.python.distribute import values_util as distribute_values_util
 from tensorflow.python.distribute import distribute_utils
 from tensorflow.python.ops.variables import VariableAggregation
-from tensorflow.python.training.tracking import data_structures
+try:  # The data_structures has been moved to the new package in tf 2.11
+  from tensorflow.python.trackable import data_structures
+except:
+  from tensorflow.python.training.tracking import data_structures
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import DistributedVariableWrapper, TrainableWrapperDistributedPolicy
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import trainable_wrapper_filter
 from tensorflow_recommenders_addons.utils.check_platform import is_macos, is_arm64

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -76,7 +76,10 @@ try:  # tf version >= 2.10.0
 except:
   from tensorflow.python.training.tracking.base import PythonStringStateSaveable as TF_PythonStringStateSaveable
 from tensorflow.python.training.tracking import base
-from tensorflow.python.training.tracking import data_structures
+try:  # The data_structures has been moved to the new package in tf 2.11
+  from tensorflow.python.trackable import data_structures
+except:
+  from tensorflow.python.training.tracking import data_structures
 from tensorflow.python.training.tracking import python_state
 from tensorflow.python.util.tf_export import tf_export
 

--- a/tensorflow_recommenders_addons/utils/ensure_tf_install.py
+++ b/tensorflow_recommenders_addons/utils/ensure_tf_install.py
@@ -17,7 +17,10 @@
 # needs to happen before anything else, since the imports below will try to
 # import TensorFlow, too.
 
-from distutils.version import LooseVersion
+try:
+  from packaging.version import Version
+except:  # make it compatible for python 3.7
+  from distutils.version import LooseVersion as Version
 import warnings
 
 import tensorflow as tf
@@ -44,10 +47,10 @@ def _check_tf_version():
     )
     return
 
-  min_version = LooseVersion(MIN_TF_VERSION)
-  max_version = LooseVersion(MAX_TF_VERSION)
+  min_version = Version(MIN_TF_VERSION)
+  max_version = Version(MAX_TF_VERSION)
 
-  if min_version <= LooseVersion(tf.__version__) <= max_version:
+  if min_version <= Version(tf.__version__) <= max_version:
     return
 
   warnings.warn(

--- a/tensorflow_recommenders_addons/utils/test_utils.py
+++ b/tensorflow_recommenders_addons/utils/test_utils.py
@@ -22,8 +22,10 @@ import numpy as np
 import pytest
 import tensorflow as tf
 
-from distutils.version import LooseVersion
-
+try:
+  from packaging.version import Version
+except:  # make it compatible for python 3.7
+  from distutils.version import LooseVersion as Version
 from tensorflow_recommenders_addons.utils import resource_loader
 
 NUMBER_OF_WORKERS = int(os.environ.get("PYTEST_XDIST_WORKER_COUNT", "1"))
@@ -102,7 +104,7 @@ def only_run_functions_eagerly(request):
 
 @pytest.fixture(scope="function", params=["float32", "mixed_float16"])
 def run_with_mixed_precision_policy(request):
-  if is_gpu_available() and LooseVersion(tf.__version__) <= "2.4.1":
+  if is_gpu_available() and Version(tf.__version__) <= "2.4.1":
     pytest.xfail("See https://github.com/tensorflow/tensorflow/issues/39775")
   tf.keras.mixed_precision.experimental.set_policy(request.param)
   yield

--- a/tensorflow_recommenders_addons/utils/tests/test_utils_test.py
+++ b/tensorflow_recommenders_addons/utils/tests/test_utils_test.py
@@ -1,4 +1,8 @@
 import random
+try:
+  from packaging.version import Version
+except:  # make it compatible for python 3.7
+  from distutils.version import LooseVersion as Version
 
 import numpy as np
 import pytest
@@ -30,12 +34,22 @@ def train_small_model():
   model.fit(x, y, epochs=1)
 
 
+@pytest.mark.skipif(
+    Version(tf.__version__) >= Version("2.13"),
+    reason=
+    "TF2.13 breakage: https://github.com/tensorflow/addons/pull/2835#issuecomment-1629772331",
+)
 @pytest.mark.with_device([tf.distribute.MirroredStrategy])
 def test_distributed_strategy(device):
   assert isinstance(device, tf.distribute.Strategy)
   train_small_model()
 
 
+@pytest.mark.skipif(
+    Version(tf.__version__) >= Version("2.13"),
+    reason=
+    "TF2.13 breakage: https://github.com/tensorflow/addons/pull/2835#issuecomment-1629772331",
+)
 @pytest.mark.with_device(["no_device"])
 @pytest.mark.needs_gpu
 def test_custom_device_placement():

--- a/tensorflow_recommenders_addons/version.py
+++ b/tensorflow_recommenders_addons/version.py
@@ -28,11 +28,11 @@ def is_arm64():
 
 # Required TensorFlow version [min, max)
 if (is_macos() and is_arm64()):
-  MIN_TF_VERSION = os.getenv("TF_VERSION", "2.6.0")
-  MAX_TF_VERSION = os.getenv("TF_VERSION", "2.8.0")
+  MIN_TF_VERSION = "2.8.0"
+  MAX_TF_VERSION = "2.11.0"
 else:
-  MIN_TF_VERSION = os.getenv("TF_VERSION", "2.6.3")
-  MAX_TF_VERSION = os.getenv("TF_VERSION", "2.8.3")
+  MIN_TF_VERSION = "2.8.3"
+  MAX_TF_VERSION = "2.11.0"
 
 # We follow Semantic Versioning (https://semver.org/)
 _MAJOR_VERSION = "0"

--- a/third_party/toolchains/tf/BUILD.tpl
+++ b/third_party/toolchains/tf/BUILD.tpl
@@ -9,7 +9,7 @@ cc_library(
 
 cc_library(
     name = "libtensorflow_framework",
-    srcs = [":libtensorflow_framework.so"],
+    srcs = ["%{TF_SHARED_LIBRARY_NAME}"],
     #data = ["lib/libtensorflow_framework.so"],
     visibility = ["//visibility:public"],
 )

--- a/tools/build_dev_container.sh
+++ b/tools/build_dev_container.sh
@@ -3,10 +3,10 @@
 set -x -e
 docker build \
     -f tools/docker/dev_container.Dockerfile \
-    --build-arg TF_VERSION=2.8.3 \
+    --build-arg TF_VERSION=2.11.0 \
     --build-arg TF_PACKAGE=tensorflow-gpu \
     --build-arg PY_VERSION=$PY_VERSION \
-    --build-arg HOROVOD_VERSION="0.23.0" \
+    --build-arg HOROVOD_VERSION=$HOROVOD_VERSION \
     --no-cache \
     --target dev_container \
     -t tfra/dev_container:latest-python$PY_VERSION ./

--- a/tools/docker/dev_container.Dockerfile
+++ b/tools/docker/dev_container.Dockerfile
@@ -1,6 +1,7 @@
 #syntax=docker/dockerfile:1.1.5-experimental
 ARG IMAGE_TYPE
 ARG PY_VERSION
+ARG HOROVOD_VERSION
 
 # Currenly all of our dev images are GPU capable but at a cost of being quite large.
 # See https://github.com/tensorflow/build/pull/47
@@ -22,7 +23,6 @@ RUN python -m pip install --upgrade pip
 COPY tools/install_deps /install_deps
 COPY requirements.txt /tmp/requirements.txt
 RUN pip install -r /install_deps/yapf.txt \
-    -r /install_deps/pytest.txt \
     -r /install_deps/typedapi.txt \
     -r /tmp/requirements.txt
 
@@ -50,7 +50,7 @@ COPY tools/docker/install/install_nccl.sh /install/
 RUN /install/install_nccl.sh "2.8.4-1+cuda11.2"
 
 COPY tools/docker/install/install_horovod.sh /install/
-RUN /install/install_horovod.sh "0.23.0"
+RUN /install/install_horovod.sh $HOROVOD_VERSION
 
 # write default env for user
 RUN echo "export TF_VERSION=$TF_VERSION" >> ~/.bashrc

--- a/tools/docker/install/install_pytest.sh
+++ b/tools/docker/install/install_pytest.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -eu
+# Copyright 2020 The TensorFlow Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+pip install -r pytest.txt

--- a/tools/docker/sanity_check.Dockerfile
+++ b/tools/docker/sanity_check.Dockerfile
@@ -1,6 +1,6 @@
 #syntax=docker/dockerfile:1.1.5-experimental
 # -------------------------------
-FROM python:3.7 as yapf-test
+FROM python:3.9 as yapf-test
 
 COPY tools/install_deps/yapf.txt ./
 RUN pip install -r yapf.txt
@@ -12,15 +12,17 @@ RUN python tools/check_python_format.py
 RUN touch /ok.txt
 
 # -------------------------------
-FROM python:3.7 as source_code_test
+FROM python:3.9 as source_code_test
 
 COPY tools/install_deps /install_deps
+COPY tools/install_deps/pytest.txt ./
+COPY tools/docker/install/install_pytest.sh /install/
+RUN bash /install/install_pytest.sh
 RUN --mount=type=cache,id=cache_pip,target=/root/.cache/pip \
     cd /install_deps && pip install \
     --default-timeout=1000 \
     -r tensorflow-cpu.txt \
-    -r typedapi.txt \
-    -r pytest.txt
+    -r typedapi.txt
 
 RUN apt-get update && apt-get install -y sudo rsync cmake
 COPY tools/install_deps/install_bazelisk.sh .bazelversion ./
@@ -43,10 +45,10 @@ RUN pytest -v -s /recommenders-addons/tools/testing/
 RUN touch /ok.txt
 
 # -------------------------------
-FROM python:3.7 as valid_build_files
+FROM python:3.9 as valid_build_files
 
-COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
+COPY tools/install_deps/tensorflow.txt ./
+RUN pip install --default-timeout=1000 -r tensorflow.txt
 
 RUN apt-get update && apt-get install sudo
 COPY tools/install_deps/install_bazelisk.sh .bazelversion ./
@@ -63,7 +65,7 @@ RUN --mount=type=cache,id=cache_bazel,target=/root/.cache/bazel \
 RUN touch /ok.txt
 
 # -------------------------------
-FROM python:3.7-alpine as clang-format
+FROM python:3.9-alpine as clang-format
 
 RUN apk add --no-cache git
 RUN git clone https://github.com/gabrieldemarmiesse/clang-format-lint-action.git
@@ -92,10 +94,10 @@ RUN touch /ok.txt
 
 # -------------------------------
 # docs tests
-FROM python:3.7 as docs_tests
+FROM python:3.9 as docs_tests
 
-COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
+COPY tools/install_deps/tensorflow.txt ./
+RUN pip install --default-timeout=1000 -r tensorflow.txt
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 
@@ -121,10 +123,10 @@ RUN touch /ok.txt
 
 # -------------------------------
 # test the editable mode
-FROM python:3.7 as test_editable_mode
+FROM python:3.9 as test_editable_mode
 
-COPY tools/install_deps/tensorflow-cpu.txt ./
-RUN pip install --default-timeout=1000 -r tensorflow-cpu.txt
+COPY tools/install_deps/tensorflow.txt ./
+RUN pip install --default-timeout=1000 -r tensorflow.txt
 COPY requirements.txt ./
 RUN pip install -r requirements.txt
 COPY tools/install_deps/pytest.txt ./

--- a/tools/install_deps/pytest.txt
+++ b/tools/install_deps/pytest.txt
@@ -1,6 +1,7 @@
-pytest~=5.3
+pytest~=6.2.5
 pytest-xdist~=1.31
 pytest-extra-durations~=0.1.3
-scikit-learn~=0.22
-Pillow~=8.0.0
+scikit-learn~=1.0.2
+scikit-image~=0.19.2
+Pillow~=9.0.1
 tqdm>=4.36.1

--- a/tools/install_deps/tensorflow-cpu.txt
+++ b/tools/install_deps/tensorflow-cpu.txt
@@ -1,1 +1,1 @@
-tensorflow-cpu==2.8.3
+tensorflow-cpu>=2.8.0,<=2.11.0

--- a/tools/install_deps/tensorflow.txt
+++ b/tools/install_deps/tensorflow.txt
@@ -1,1 +1,1 @@
-tensorflow==2.8.3
+tensorflow>=2.8.0,<=2.11.0

--- a/tools/run_gpu_tests.sh
+++ b/tools/run_gpu_tests.sh
@@ -6,9 +6,9 @@ export DOCKER_BUILDKIT=1
 docker build \
        -f tools/docker/build_wheel.Dockerfile \
        --target tfra_gpu_tests \
-       --build-arg TF_VERSION=2.8.3 \
+       --build-arg TF_VERSION=2.11.0 \
        --build-arg TF_NEED_CUDA=1 \
        --build-arg TF_NAME="tensorflow-gpu" \
-       --build-arg PY_VERSION=3.8 \
+       --build-arg PY_VERSION=3.9 \
        -t tfra_gpu_tests ./
 docker run --rm -t -v cache_bazel:/root/.cache/bazel --gpus=all tfra_gpu_tests


### PR DESCRIPTION
# Description

Brief Description of the PR:
This pull request aims to enhance the project's compatibility by making it compatible with TensorFlow versions 2.6.0 to 2.11.0.

## Type of change
1. Added compatible import statements for Adam, Version, and data_structures.
2. Updated the building scripts and Docker files.
3. Decoupled TensorFlow dependencies so that users don't need to reinstall TensorFlow with the TFRA wheels.
4. Added CI/CD tasks to build wheels with both the minimum and maximum TensorFlow versions.

- [ ] Bug fix
- [x] CICD
- [ ] New Tutorial
- [x] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature


# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature, please describe the tests that you ran to verify your changes:

I tested the CI/CD with multiple TensorFlow versions in my repository. The code is working with TensorFlow versions between 2.6.0 to 2.11.0. However, for simplifying the pipeline, I only kept the minimum tasks.