### PR TITLE
[Fix] Several bugs when using HvdAllToAllEmbedding to train model and save/restore KV files.

### DIFF
--- a/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
+++ b/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
@@ -466,12 +466,12 @@ def export_to_savedmodel(model, savedmodel_dir):
 
   # TFRA modify the Keras save function with a patch.
   # !!!! Run save_model function in all rank !!!!
-  de.keras.models.de_hvd_save_model(model,
-                                    savedmodel_dir,
-                                    overwrite=True,
-                                    include_optimizer=True,
-                                    save_traces=True,
-                                    options=save_options)
+  de.keras.models.de_save_model(model,
+                                savedmodel_dir,
+                                overwrite=True,
+                                include_optimizer=True,
+                                save_traces=True,
+                                options=save_options)
 
 
 def export_for_serving(model, export_dir):
@@ -521,7 +521,7 @@ def export_for_serving(model, export_dir):
 
   # TFRA modify the Keras save function with a patch.
   # !!!! Run save_model function in all rank !!!!
-  de.keras.models.de_hvd_save_model(
+  de.keras.models.de_save_model(
       model,
       export_dir,
       overwrite=True,

--- a/docs/api_docs/tfra/dynamic_embedding/keras/layers/HvdAllToAllEmbedding.md
+++ b/docs/api_docs/tfra/dynamic_embedding/keras/layers/HvdAllToAllEmbedding.md
@@ -83,7 +83,7 @@ In addition, we also provide parameter initialization and save callback related 
 
 [`dynamic_embedding.keras.callbacks.DEHvdModelCheckpoint`](https://github.com/tensorflow/recommenders-addons/blob/master/tensorflow_recommenders_addons/dynamic_embedding/python/keras/callbacks.py)
 
-[`dynamic_embedding.keras.models.de_hvd_save_model`](https://github.com/tensorflow/recommenders-addons/blob/master/tensorflow_recommenders_addons/dynamic_embedding/python/keras/models.py)
+[`dynamic_embedding.keras.models.de_save_model`](https://github.com/tensorflow/recommenders-addons/blob/master/tensorflow_recommenders_addons/dynamic_embedding/python/keras/models.py)
 
 [`dynamic_embedding.train.DEHvdModelCheckpoint`](https://github.com/tensorflow/recommenders-addons/blob/master/tensorflow_recommenders_addons/dynamic_embedding/python/train/checkpoint.py)
 


### PR DESCRIPTION
# Description

### **BUG1**
The id key may be multiple copies in one tensor before real shadow lookup when using HvdAllToAllEmbedding.
Here is how the bug happens. 

**Before ALL2ALL:**
Rank0 IDs: [0,1,1,3,3] --unique-->  [0,1,3]
Rank1 IDs: [0,1,2,2,3] --unique-->  [0,1,2,3]
**After ALL2ALL:**
Rank0 IDs: [0,0,2]
Rank1 IDs: [1,1,3,3]

Rank0 has duplicated key 0, and Rank1 has duplicated keys 1 and 3. When updating the gradient, in Rank0, the key 0 will insert twice which means only one gradient takes effect and another one was covered. That may lead to under-training, same as Rank1 because of multiple copies of key 1 and key 3.

So we need to do secondary unique operation after ALL2ALL. The first time for reducing transmission overhead, the second time for training properly.

### **BUG2**
Fix bug that de_hvd_save_model and CheckpointManager were unable to use together.  Which cause by CheckpointManager compatibility code in DE hack changing the storage path in DE saveable object when runtime. The modified storage path was not wrote back after Checkpoint saving, and then when call saved_model saving function it would dump to an unexpected directory which was set in DECheckpoint class.

### **Others**
Modify function name de_hvd_save_model to de_save_model.
Also make user more easy to use de_save_model by writing fewer code.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [x] Updated or additional documentation
- [x] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Train any model using HvdAllToAllEmbedding, and comparing the loss between set parameter with_secondary_unique True and False.

Run the new test.
