### PR TITLE
[Feat] Compatible with TensorFlow 2.15

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_table_op_util.hpp
@@ -273,32 +273,32 @@ Status ParseJsonConfig(const std::string *const redis_config_abs_dir,
     }                                                                 \
   }
 
-#define ReadArrayJsonToParams(json_key_name, json_val_type)                  \
-  {                                                                          \
-    json_hangar_it = json_hangar.find(#json_key_name);                       \
-    if (json_hangar_it != json_hangar.end()) {                               \
-      if (json_hangar_it->second->type == json_array) {                      \
-        redis_connection_params->json_key_name.clear();                      \
-        for (unsigned i = 0; i < json_hangar_it->second->u.array.length;     \
-             ++i) {                                                          \
-          value_depth1 = json_hangar_it->second->u.array.values[i];          \
-          if (value_depth1->type == json_##json_val_type) {                  \
-            redis_connection_params->redis_host_port.push_back(              \
-                value_depth1->u.json_val_type);                              \
-          } else {                                                           \
-            LOG(ERROR) << #json_key_name " should be json " #json_val_type   \
-                                         " array";                           \
-            return ReturnInvalidArgumentStatus(                              \
-                " should be json " #json_val_type " array");                 \
-          }                                                                  \
-        }                                                                    \
-      } else {                                                               \
-        LOG(ERROR) << #json_key_name " should be json " #json_val_type       \
-                                     " array";                               \
-        return ReturnInvalidArgumentStatus(" should be json " #json_val_type \
-                                           " array");                        \
-      }                                                                      \
-    }                                                                        \
+#define ReadArrayJsonToParams(json_key_name, json_val_type)                 \
+  {                                                                         \
+    json_hangar_it = json_hangar.find(#json_key_name);                      \
+    if (json_hangar_it != json_hangar.end()) {                              \
+      if (json_hangar_it->second->type == json_array) {                     \
+        redis_connection_params->json_key_name.clear();                     \
+        for (unsigned i = 0; i < json_hangar_it->second->u.array.length;    \
+             ++i) {                                                         \
+          value_depth1 = json_hangar_it->second->u.array.values[i];         \
+          if (value_depth1->type == json_##json_val_type) {                 \
+            redis_connection_params->redis_host_port.push_back(             \
+                value_depth1->u.json_val_type);                             \
+          } else {                                                          \
+            LOG(ERROR) << #json_key_name " should be json " #json_val_type  \
+                                         " array";                          \
+            return ReturnInvalidArgumentStatus(                             \
+                #json_key_name " should be json " #json_val_type " array"); \
+          }                                                                 \
+        }                                                                   \
+      } else {                                                              \
+        LOG(ERROR) << #json_key_name " should be json " #json_val_type      \
+                                     " array";                              \
+        return ReturnInvalidArgumentStatus(                                 \
+            #json_key_name " should be json " #json_val_type " array");     \
+      }                                                                     \
+    }                                                                       \
   }
 
 #define ReadStringArrayJsonToParams(json_key_name)                           \

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_table_op.cc
@@ -599,8 +599,12 @@ class RedisTableOfTensors final : public LookupInterface {
               hscan_reply->elements > 1) {
             kvs_reply = hscan_reply->element[1];
             // fill Tensor keys and values
+            if (kvs_reply->elements < 2 && cursor == 0) {
+              // Find nothing in Redis
+              break;
+            }
             if constexpr (!std::is_same<V, tstring>::value) {
-              if (kvs_reply->element[0]->len !=
+              if (kvs_reply->element[1]->len !=
                   runtime_value_dim_ * sizeof(V)) {
                 return errors::InvalidArgument(
                     "Embedding dim in Redis server is not equal to the OP "
@@ -1035,8 +1039,12 @@ class RedisTableOfTensors final : public LookupInterface {
         }
         kvs_reply = hscan_reply->element[1];
         // fill Tensor keys and values
+        if (kvs_reply->elements < 2 && cursor == 0) {
+          // Find nothing in Redis
+          break;
+        }
         if constexpr (!std::is_same<V, tstring>::value) {
-          if (kvs_reply->element[0]->len != runtime_value_dim_ * sizeof(V)) {
+          if (kvs_reply->element[1]->len != runtime_value_dim_ * sizeof(V)) {
             return errors::InvalidArgument(
                 "Embedding dim in Redis server is not equal to the OP runtime "
                 "dim.");
@@ -1146,8 +1154,12 @@ class RedisTableOfTensors final : public LookupInterface {
         }
         kvs_reply = hscan_reply->element[1];
         // fill Tensor keys and values
+        if (kvs_reply->elements < 2 && cursor == 0) {
+          // Find nothing in Redis
+          break;
+        }
         if constexpr (!std::is_same<V, tstring>::value) {
-          if (kvs_reply->element[0]->len != runtime_value_dim_ * sizeof(V)) {
+          if (kvs_reply->element[1]->len != runtime_value_dim_ * sizeof(V)) {
             return errors::InvalidArgument(
                 "Embedding dim in Redis server is not equal to the OP runtime "
                 "dim.");

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
@@ -29,7 +29,11 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops import dynamic_
 
 from tensorflow.python.distribute import distribute_lib
 from tensorflow.python.keras.utils import tf_utils
-from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
+try:  # tf version >= 2.14.0
+  from tensorflow.python.distribute import distribute_lib as distribute_ctx
+  assert hasattr(distribute_ctx, 'has_strategy')
+except:
+  from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
 from tensorflow.python.distribute import values_util
 from tensorflow.python.framework import ops
 from tensorflow.python.eager import tape

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_ops_test.py
@@ -54,6 +54,10 @@ from tensorflow.python.ops import resource_variable_ops
 from tensorflow.python.ops import script_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.ops import variable_scope
+try:  # tf version >= 2.14.0
+  from tensorflow.python.ops.array_ops_stack import stack
+except:
+  from tensorflow.python.ops.array_ops import stack
 from tensorflow.python.platform import test
 from tensorflow.python.training import device_setter
 from tensorflow.python.training import server_lib
@@ -309,7 +313,7 @@ class EmbeddingLookupTest(test.TestCase):
       embedding = de.embedding_lookup(embeddings, ids, max_norm=2.0)
       norms = math_ops.sqrt(
           math_ops.reduce_sum(embedding_no_norm * embedding_no_norm, axis=1))
-      normalized = embedding_no_norm / array_ops.stack([norms, norms], axis=1)
+      normalized = embedding_no_norm / stack([norms, norms], axis=1)
       self.assertAllCloseAccordingToType(embedding.eval(),
                                          2 * self.evaluate(normalized))
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_variable_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_variable_test.py
@@ -57,7 +57,10 @@ from tensorflow.python.training import adam
 from tensorflow.python.training import saver
 from tensorflow.python.training import server_lib
 from tensorflow.python.training import training
-from tensorflow.python.training.tracking import util as track_util
+try:  # tf version >= 2.14.0
+  from tensorflow.python.checkpoint.checkpoint import Checkpoint
+except:
+  from tensorflow.python.training.tracking.util import Checkpoint
 from tensorflow.python.util import compat
 from tensorflow_estimator.python.estimator import estimator
 from tensorflow_estimator.python.estimator import estimator_lib
@@ -1326,13 +1329,13 @@ class VariableTest(test.TestCase):
           *sorted(zip(keys1, vals1), key=lambda x: x[0], reverse=False))
       slot_keys_and_vals1 = [sv.export() for sv in model1.slot_vars]
 
-      ckpt1 = track_util.Checkpoint(model=model1, optimizer=model1.optmz)
+      ckpt1 = Checkpoint(model=model1, optimizer=model1.optmz)
       ckpt_dir = self.get_temp_dir()
       model_path = ckpt1.save(ckpt_dir)
       del model1
 
       model2 = TestModel()
-      ckpt2 = track_util.Checkpoint(model=model2, optimizer=model2.optmz)
+      ckpt2 = Checkpoint(model=model2, optimizer=model2.optmz)
       model2.train(features)  # Pre-build trace before restore.
       ckpt2.restore(model_path)
       loss2 = model2(features)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/restrict_policies.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/restrict_policies.py
@@ -26,6 +26,10 @@ from tensorflow.python.ops import gen_logging_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import nn_ops
 from tensorflow.python.ops import variable_scope
+try:  # tf version >= 2.14.0
+  from tensorflow.python.ops.cond import cond
+except:
+  from tensorflow.python.ops.control_flow_ops import cond
 from tensorflow.python.platform import tf_logging
 
 
@@ -195,8 +199,7 @@ class TimestampRestrictPolicy(RestrictPolicy):
       raise TypeError('trigger should be integer.')
 
     is_oversize = math_ops.greater(self.var.size(), trigger)
-    return control_flow_ops.cond(is_oversize, self._cond_restrict_fn,
-                                 control_flow_ops.no_op)
+    return cond(is_oversize, self._cond_restrict_fn, control_flow_ops.no_op)
 
   def _cond_restrict_fn(self):
     """
@@ -322,8 +325,7 @@ class FrequencyRestrictPolicy(RestrictPolicy):
       raise TypeError('trigger should be integer.')
 
     is_oversize = math_ops.greater(self.var.size(), trigger)
-    return control_flow_ops.cond(is_oversize, self._cond_restrict_fn,
-                                 control_flow_ops.no_op)
+    return cond(is_oversize, self._cond_restrict_fn, control_flow_ops.no_op)
 
   def _cond_restrict_fn(self):
     """

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -42,6 +42,10 @@ from tensorflow.python.eager import context
 from tensorflow.python.framework import device as pydev
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
+try:  # tf version >= 2.14.0
+  from tensorflow.python.framework.tensor import Tensor
+except:
+  from tensorflow.python.framework.ops import Tensor
 try:  # tf version >= 2.13.0
   from tensorflow.python.framework.indexed_slices import IndexedSlices
 except:
@@ -129,7 +133,7 @@ def _get_processor(v):
   if isinstance(v, de.TrainableWrapper):
     return _DenseDynamicEmbeddingTrainableProcessor(v)
   if context.executing_eagerly():
-    if isinstance(v, ops.Tensor):
+    if isinstance(v, Tensor):
       return optimizer._TensorProcessor(v)
     else:
       return optimizer._DenseResourceVariableProcessor(v)
@@ -140,7 +144,7 @@ def _get_processor(v):
     return optimizer._DenseResourceVariableProcessor(v)
   if isinstance(v, variables.Variable):
     return optimizer._RefVariableProcessor(v)
-  if isinstance(v, ops.Tensor):
+  if isinstance(v, Tensor):
     return optimizer._TensorProcessor(v)
   raise NotImplementedError("Trying to optimize unsupported type ", v)
 


### PR DESCRIPTION
# Description

Brief Description of the PR:

- Be compatible with TensorFlow 2.15 by calling the origin python function from new directory.
- Fix some test should not be run when eager mode. Also add more new test for Redis KV backend.
- Fix Redis backend json config file would not printed when a wrong json value type was set.
- Fix check wrong array index in kvs_reply from Redis returning. Wanted to check the length of value, but the length of key was checked.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Run all test script under TF2.15 environment.
