### PR TITLE
[Fix] Compiling error in TF2.13 

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/utils/utils.h
@@ -42,6 +42,11 @@ This code is for compatibility.*/
 }  // namespace recommenders_addons
 }  // namespace tensorflow
 
+#ifndef MAYBE_ADD_SOURCE_LOCATION
+#define MAYBE_ADD_SOURCE_LOCATION(status) \
+  {}
+#endif  // MAYBE_ADD_SOURCE_LOCATION
+
 // For propagating errors when calling a function but not return status.
 #if TF_VERSION_INTEGER >= 2130
 #define TFRA_LOG_IF_ERROR(...)             \


### PR DESCRIPTION
# Description

There is no definitions macro MAYBE_ADD_SOURCE_LOCATION under TF 2.13.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

compile it with TF2.13
