### PR TITLE
[Fix] Compatible with TF2.15 register_checkpoint_saver when multiple TFRA Embedding in one trackables.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_save_restore_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_save_restore_patch.py
@@ -98,6 +98,7 @@ def _de_var_fs_restore_fn(trackables, merged_prefix):
   variables_folder_dir = string_ops.regex_replace(merged_prefix,
                                                   pattern='/([^/]*)$',
                                                   rewrite='')
+  load_ops = tf_utils.ListWrapper([])
   for obj_prefix, obj in trackables.items():
     if not hasattr(obj, 'saveable'):
       continue
@@ -109,9 +110,11 @@ def _de_var_fs_restore_fn(trackables, merged_prefix):
         else:
           de_variable_folder_dir = string_ops.string_join(
               [variables_folder_dir, 'TFRADynamicEmbedding'], separator='/')
-        return load_de_variable_from_file_system(
-            saveable.op, de_variable_folder_dir, saveable.proc_size,
-            saveable.proc_rank, saveable._saver_config.buffer_size)
+        load_ops.as_list().append(
+            load_de_variable_from_file_system(
+                saveable.op, de_variable_folder_dir, saveable.proc_size,
+                saveable.proc_rank, saveable._saver_config.buffer_size))
+  return load_ops.as_list()
 
 
 class _DynamicEmbeddingSingleDeviceSaver(functional_saver._SingleDeviceSaver):


### PR DESCRIPTION
# Description

In my previous tests, there was only one TFRA Embedding object passed into the trackables in the save loading function, even though there were multiple TFRA Embedding objects in the model. 
However, we have tested that under certain composition conditions, the trackables may contain multiple TFRA Embedding, so the group of multiple loading functions should be returned.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [x] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Run the test.
