### PR TITLE
[Fix] Stack overflow in Redis Backend and RestrictPolicy couldn't be saved when using DE embedding layer.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_connection_util.hpp
@@ -23,8 +23,10 @@ limitations under the License.
 #include <unistd.h>
 
 #include <cmath>
+#include <cstddef>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 #include "md5.h"
 #include "tensorflow/core/framework/tensor.h"
@@ -69,13 +71,14 @@ inline unsigned long get_file_size(const std::string path) {
 }
 
 inline int createDirectory(const std::string path) {
-  int len = path.length();
-  char tmpDirPath[1024] = {0};
-  for (int i = 0; i < len; i++) {
+  size_t len = path.size();
+  std::vector<char> tmpDirPath;
+  tmpDirPath.resize(len);
+  for (size_t i = 0; i < len; i++) {
     tmpDirPath[i] = path[i];
     if (tmpDirPath[i] == '\\' || tmpDirPath[i] == '/') {
-      if (access(tmpDirPath, 0) == -1) {
-        int ret = mkdir(tmpDirPath, S_IRWXU | S_IRWXG | S_IRWXO);
+      if (access(tmpDirPath.data(), 0) == -1) {
+        int ret = mkdir(tmpDirPath.data(), S_IRWXU | S_IRWXG | S_IRWXO);
         if (ret == -1) return ret;
       }
     }

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -569,6 +569,8 @@ class Variable(base.Trackable):
       if not issubclass(restrict_policy, de.RestrictPolicy):
         raise TypeError('restrict_policy must be subclass of RestrictPolicy.')
       self._restrict_policy = restrict_policy(self)
+      _restrict_var = self._restrict_policy._restrict_var
+      self._track_trackable(_restrict_var, _restrict_var.name, overwrite=False)
     else:
       self._restrict_policy = None
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/restrict_policies.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/restrict_policies.py
@@ -154,6 +154,7 @@ class TimestampRestrictPolicy(RestrictPolicy):
                                       trainable=False,
                                       init_size=self.var.init_size,
                                       kv_creator=self.var.kv_creator)
+      self._restrict_var = self.tstp_var
 
   def apply_update(self, ids):
     """
@@ -272,6 +273,7 @@ class FrequencyRestrictPolicy(RestrictPolicy):
                                       trainable=False,
                                       init_size=self.var.init_size,
                                       kv_creator=self.var.kv_creator)
+      self._restrict_var = self.freq_var
 
   def apply_update(self, ids):
     """


### PR DESCRIPTION
# Description

Fix tmpDirPath with fixed size may cause stack overflow in Redis backend. The char size of the entered file path may exceed 1024. Fixes #405 
Fix restrict_policy wasn't tracked when using Embedding layer. Fixes #385 



## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [x] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

When using redis backend, enter a non-existent file path that is longer than 1024.
