### PR TITLE
[feature]support ragged tensor in all2all

### DIFF
--- a/.github/workflows/make_wheel_macOS_arm64.sh
+++ b/.github/workflows/make_wheel_macOS_arm64.sh
@@ -28,6 +28,13 @@ python -m pip install \
   --only-binary=:all: \
   protobuf~=$PROTOBUF_VERSION $TF_NAME==$TF_VERSION
 
+# For tensorflow version 2.11.0, and python version = 3.10 and 3.9
+# numpy>=1.20 is required, then it will install numpy 2.0 and cause errors.
+PYTHON_VERSION=$(python -V | cut -d' ' -f2 | cut -d'.' -f1,2)
+if [[ "$TF_VERSION" == "2.11.0" && ( "$PYTHON_VERSION" == "3.9" || "$PYTHON_VERSION" == "3.10" ) ]]; then
+  python -m pip install numpy==1.26.4 --force-reinstall
+fi
+
 python configure.py
 
 bazel build \

--- a/.github/workflows/make_wheel_macOS_x86.sh
+++ b/.github/workflows/make_wheel_macOS_x86.sh
@@ -14,6 +14,13 @@ fi
 
 brew install open-mpi
 python -m pip install --default-timeout=1000 delocate==0.10.3 wheel==0.36.2 setuptools tensorflow==$TF_VERSION
+# For tensorflow version 2.11.0, and python version = 3.10 and 3.9
+# numpy>=1.20 is required, then it will install numpy 2.0 and cause errors.
+PYTHON_VERSION=$(python -V | cut -d' ' -f2 | cut -d'.' -f1,2)
+if [[ "$TF_VERSION" == "2.11.0" && ( "$PYTHON_VERSION" == "3.9" || "$PYTHON_VERSION" == "3.10" ) ]]; then
+  python -m pip install numpy==1.26.4 --force-reinstall
+fi
+
 python -m pip install tensorflow-io
 python -m pip install --upgrade protobuf~=$PROTOBUF_VERSION
 

--- a/rfcs/20200424-sparse-domain-isolation.md
+++ b/rfcs/20200424-sparse-domain-isolation.md
@@ -564,7 +564,7 @@ def create_slots(primary, init, slot_name, op_name):
 We define a special version of `Processor` for `TrainableWrapper`:
 
 ```python
-import tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import TrainableWrapper
 
 
 class _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
@@ -628,7 +628,7 @@ class _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
 def _get_processor(v):
   """The processor of v."""
   # ...
-  if isinstance(v, tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable.TrainableWrapper):
+  if isinstance(v, TrainableWrapper):
     return _DenseDynamicEmbeddingTrainableProcessor(v)  # get processor for `TrainableWrapper`
   # ...
 ```

--- a/rfcs/20200424-sparse-domain-isolation.md
+++ b/rfcs/20200424-sparse-domain-isolation.md
@@ -564,13 +564,15 @@ def create_slots(primary, init, slot_name, op_name):
 We define a special version of `Processor` for `TrainableWrapper`:
 
 ```python
+import tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable
+
 
 class _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
   """Processor for TrainableWrapper."""
 
   def update_op(self, optimizer, g):
-   
-    # The `update_op` is a insert-like operation of `Trainclass _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
+
+  # The `update_op` is a insert-like operation of `Trainclass _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
   """Processor for dense DynamiceEmbedding."""
 
   def __init__(self, v):
@@ -583,20 +585,20 @@ class _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
     # pylint: disable=protected-access
     # for better convergence:
 
-    with ops.colocate_with(None,  ignore_existing=True):
+    with ops.colocate_with(None, ignore_existing=True):
       _slots = [
-          optimizer.get_slot(self._v, _s) for _s in optimizer.get_slot_names()
+        optimizer.get_slot(self._v, _s) for _s in optimizer.get_slot_names()
       ]
       with ops.control_dependencies([g]):
         _before = [self._v.read_value()] + [_s.read_value() for _s in _slots]
       if isinstance(g, ops.IndexedSlices):
         if self._v.constraint is not None:
           raise RuntimeError(
-              "Cannot use a constraint function on a sparse variable.")
+            "Cannot use a constraint function on a sparse variable.")
 
         with ops.control_dependencies(_before):
           _apply_op = optimizer._resource_apply_sparse_duplicate_indices(
-              g.values, self._v, g.indices)
+            g.values, self._v, g.indices)
         with ops.control_dependencies([_apply_op]):
           _after = control_flow_ops.group([self._v.update_op()] +
                                           [_s.update_op() for _s in _slots])
@@ -610,20 +612,23 @@ class _DenseDynamicEmbeddingTrainableProcessor(_OptimizableVariable):
         with ops.control_dependencies([_apply_op]):
           _after = control_flow_ops.group([self._v.update_op()] +
                                           [_s.update_op() for _s in _slots])
-        return _afterableWrapper`
+        return _afterableWrapper
+        `
     # which write back the trained values hold Temporarily in primary and slots `TrainableWrapper`.
     _apply_op = optimizer._resource_apply_dense(g, self._v)
     with ops.control_dependencies([_apply_op]):
-      _update = control_flow_ops.group([self._v.update_op()] + \
+      _update = control_flow_ops.group([self._v.update_op()] +
                                        [_s.update_op()
                                         for _s in dynamic_embedding_ops.get_slots(self._v)])
     return _update
+
+
 #  ...
 
 def _get_processor(v):
   """The processor of v."""
   # ...
-  if isinstance(v, resource_variable_ops.TrainableWrapper):
+  if isinstance(v, tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable.TrainableWrapper):
     return _DenseDynamicEmbeddingTrainableProcessor(v)  # get processor for `TrainableWrapper`
   # ...
 ```

--- a/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
@@ -80,7 +80,7 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embeddi
     get_model_mode,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
     trainable_wrapper_filter,)
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import (
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import (
     ModelMode,
     TrainableWrapper,
 )

--- a/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/__init__.py
@@ -64,7 +64,7 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops.hkv_hashtable_o
     HkvHashTable,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.redis_table_ops import (
     RedisTable,)
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
     embedding_lookup,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
     embedding_lookup_sparse,)
@@ -80,18 +80,20 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embeddi
     get_model_mode,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
     trainable_wrapper_filter,)
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
-    ModelMode,)
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
-    TrainableWrapper,)
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import (
-    DistributedVariableWrapper,)
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import (
+    ModelMode,
+    TrainableWrapper,
+)
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.distributed_embedding_variable import \
+    DistributedVariableWrapper
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_optimizer import (
     create_slots,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_optimizer import (
     DynamicEmbeddingOptimizer,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
-    get_variable,)
+    get_variable,
+    embedding_lookup,
+)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (
     Variable,)
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import (

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/callbacks.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/callbacks.py
@@ -21,14 +21,11 @@ from tensorflow.python.framework import versions
 from tensorflow.python.keras import backend as K
 from tensorflow.python.keras import callbacks
 from tensorflow.python.keras.utils import tf_utils
-from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.platform import tf_logging as logging
-from tensorflow.python.util.deprecation import deprecated
 
 from tensorflow_recommenders_addons.dynamic_embedding.python.keras.layers import HvdAllToAllEmbedding
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import TrainableWrapper, DEResourceVariable
-from tensorflow_recommenders_addons.utils.check_platform import is_macos, is_arm64
+from tensorflow_recommenders_addons import dynamic_embedding as de
 
 try:
   import horovod.tensorflow as hvd
@@ -72,8 +69,8 @@ class DEHvdBroadcastGlobalVariablesCallbackImpl(object):
       if hvd._executing_eagerly() and hasattr(self.model, 'variables'):
         # TensorFlow 2.0 or TensorFlow eager
         filter_lambda = lambda x: (x.ref() not in self._local_vars) and (
-            not isinstance(x, TrainableWrapper)) and (not isinstance(
-                x, DEResourceVariable))
+            not isinstance(x, de.TrainableWrapper)) and (not isinstance(
+                x, de.DEResourceVariable))
         broadcast_vars = [
             var for var in self.model.variables if filter_lambda(var)
         ]
@@ -127,7 +124,8 @@ class DEHvdModelCheckpoint(callbacks.ModelCheckpoint):
     else:
       de_dir = os.path.join(filepath, "variables", "TFRADynamicEmbedding")
       for var in self.model.variables:
-        if not hasattr(var, "params") or not isinstance(var, TrainableWrapper):
+        if not hasattr(var, "params") or not isinstance(var,
+                                                        de.TrainableWrapper):
           continue
         if not hasattr(var.params, "_created_in_class"):
           continue

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
@@ -26,6 +26,8 @@ from tensorflow_recommenders_addons.dynamic_embedding.python.ops import dynamic_
 
 from tensorflow.python.keras.utils import tf_utils
 
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import HvdVariable
+
 try:  # tf version >= 2.14.0
   from tensorflow.python.distribute import distribute_lib as distribute_ctx
 
@@ -42,7 +44,7 @@ try:  # The data_structures has been moved to the new package in tf 2.11
 except:
   from tensorflow.python.training.tracking import data_structures
 
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import make_partition, \
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import \
   TrainableWrapperDistributedPolicy
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_save_restore_patch import de_fs_saveable_class_names
 
@@ -524,27 +526,14 @@ class HvdAllToAllEmbedding(BasicEmbedding):
   This embedding layer will dispatch keys to all corresponding Horovod workers and receive its own keys for distributed training before embedding_lookup.
   """
 
-  def __init__(self,
-               with_unique=True,
-               with_secondary_unique=True,
-               mpi_size=None,
-               batch_size=None,
-               *args,
-               **kwargs):
-    try:
-      import horovod.tensorflow as hvd
-    except ImportError:
-      raise ValueError(
-          "Please install Horovod properly first if you want to use distributed synchronous training based on Horovod"
-      )
-    self.hvd = hvd
-    self.with_unique = with_unique
-    self.with_secondary_unique = with_secondary_unique
-    self.batch_size = batch_size
-    if mpi_size is None:
-      self._mpi_size = self.hvd.size()
-    else:
-      self._mpi_size = mpi_size
+  def __init__(
+      self,
+      with_unique=True,
+      with_secondary_unique=True,
+      mpi_size=None,
+      batch_size=None,  # not used for now, reserved for assert on all nodes have the same batch size
+      *args,
+      **kwargs):
     super(HvdAllToAllEmbedding, self).__init__(*args, **kwargs)
     try:
       assert type(self.params.saveable).__name__ in de_fs_saveable_class_names
@@ -553,67 +542,9 @@ class HvdAllToAllEmbedding(BasicEmbedding):
           "Please use FileSystemSaver in KVCreator when use HvdAllToAllEmbedding. "
           "It will allow TFRA save and restore KV files when Embedding tensor parallel in distributed training. "
       )
-
-  def __relocate_dense_feature__(self, ids, batch_size=None):
-    """
-    Args:
-      ids: A 2-D Tensor with shape: (batch_size, sequence_length) or a 1-D Tensor with shape: (batch_size,). 
-        If batch_size is provided, then it trust the batch_size argument, to avoid new an OP instead.
-      batch_size: Integer or a int32/int64 scalar. All ranks must have same batch_size.
-        Otherwise will make undefined behavior.
-
-    Returns:
-      flat_reloc_ids: a flat ids partitioned to each rank.
-    """
-    if ids.dtype not in (tf.int32, tf.int64):
-      raise NotImplementedError
-
-    if ids.shape.rank > 2:
-      raise NotImplementedError(
-          'Input ids must be shape '
-          f'(batch_size, sequence_length) or (batch_size,), but get {ids.shape}'
-      )
-
-    if batch_size is None:
-      input_shape = tf.shape(ids)
-      batch_size = input_shape[0]
-
-    partition_index = self.params.partition_fn(ids, self._mpi_size)
-    ids_partitions, ids_indices = make_partition(ids, partition_index,
-                                                 self._mpi_size)
-    partitions_sizes = tf.stack([tf.size(p) for p in ids_partitions], axis=0)
-    relocs_tensor = tf.concat(ids_partitions, axis=0)
-    flat_reloc_ids, remote_sizes = self.hvd.alltoall(relocs_tensor,
-                                                     splits=partitions_sizes)
-    return flat_reloc_ids, remote_sizes, ids_indices
-
-  def __alltoall_embedding_lookup__(self, ids):
-    if self._mpi_size == 1:
-      return de.shadow_ops.embedding_lookup(self.shadow, ids)
-    if isinstance(ids, tf.sparse.SparseTensor):
-      raise NotImplementedError('SparseTensor is not supported yet.')
-
-    input_shape = tf.shape(ids)
-    if self.batch_size is None:
-      batch_size_runtime = input_shape[0]
-
-    reloc_ids, remote_sizes, gather_indices = self.__relocate_dense_feature__(
-        ids, batch_size=batch_size_runtime)
-
-    if self.with_secondary_unique:
-      with tf.name_scope(self.name + "/EmbeddingWithUnique"):
-        reloc_unique_ids, reloc_unique_idx = tf.unique(reloc_ids)
-        reloc_unique_embeddings = de.shadow_ops.embedding_lookup(
-            self.shadow, reloc_unique_ids)
-        lookup_result = tf.gather(reloc_unique_embeddings, reloc_unique_idx)
-    else:
-      lookup_result = de.shadow_ops.embedding_lookup(self.shadow, reloc_ids)
-    lookup_result, _ = self.hvd.alltoall(lookup_result, splits=remote_sizes)
-
-    recover_shape = tf.concat((input_shape, (self.embedding_size,)), axis=0)
-    gather_indices = tf.expand_dims(tf.concat(gather_indices, axis=0), axis=-1)
-    lookup_result = tf.scatter_nd(gather_indices, lookup_result, recover_shape)
-    return lookup_result
+    self.hvd_variable = HvdVariable(self.name, self.shadow, self.embedding_size,
+                                    with_unique, with_secondary_unique,
+                                    mpi_size)
 
   def call(self, ids):
     """
@@ -630,13 +561,13 @@ class HvdAllToAllEmbedding(BasicEmbedding):
 
     from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import \
       embedding_lookup_unique_base
-    return embedding_lookup_unique_base(ids, self.embedding_size,
-                                        self.__alltoall_embedding_lookup__,
-                                        self.with_unique, self.name)
+    return embedding_lookup_unique_base(
+        ids, self.embedding_size,
+        self.hvd_variable.__alltoall_embedding_lookup__, self.with_unique,
+        self.name)
 
   def get_config(self):
     config = super(HvdAllToAllEmbedding, self).get_config()
     config.update({"with_unique": self.with_unique})
-    config.update({"mpi_size": self._mpi_size})
-    config.update({"batch_size": self.batch_size})
+    config.update({"mpi_size": self.hvd_variable._mpi_size})
     return config

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
@@ -42,9 +42,8 @@ try:  # The data_structures has been moved to the new package in tf 2.11
 except:
   from tensorflow.python.training.tracking import data_structures
 
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import \
-  DistributedVariableWrapper, TrainableWrapperDistributedPolicy
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import make_partition
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import make_partition, \
+  TrainableWrapperDistributedPolicy
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_save_restore_patch import de_fs_saveable_class_names
 
 
@@ -244,7 +243,7 @@ class Embedding(tf.keras.layers.Layer):
     ) and self.distribute_strategy and 'OneDeviceStrategy' not in str(
         self.distribute_strategy) and not values_util.is_saving_non_distributed(
         ) and values_util.get_current_replica_id_as_int() is not None:
-      self.shadow = DistributedVariableWrapper(
+      self.shadow = de.DistributedVariableWrapper(
           self.distribute_strategy, self.shadow_impl.as_list(),
           VariableAggregation.NONE,
           TrainableWrapperDistributedPolicy(VariableAggregation.NONE))

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/distributed_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/distributed_embedding_variable.py
@@ -1,0 +1,16 @@
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import IEmbeddingVariable
+from tensorflow.python.distribute import values as distribute_values_lib
+
+
+class DistributedVariableWrapper(IEmbeddingVariable,
+                                 distribute_values_lib.DistributedVariable):
+
+  def __init__(self, strategy, values, aggregation, var_policy=None):
+    super(DistributedVariableWrapper, self).__init__(strategy, values,
+                                                     aggregation, var_policy)
+    self.shadow = values[0]
+
+  def verify_embedding_weights(self, sparse_ids, sparse_weights=None):
+    IEmbeddingVariable.verify_embedding_param_weights(self.shadow.params,
+                                                      sparse_ids,
+                                                      sparse_weights)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/distributed_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/distributed_embedding_variable.py
@@ -1,16 +1,24 @@
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import IEmbeddingVariable
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights
 from tensorflow.python.distribute import values as distribute_values_lib
 
+import tensorflow as tf
 
-class DistributedVariableWrapper(IEmbeddingVariable,
+
+class DistributedVariableWrapper(EmbeddingWeights,
                                  distribute_values_lib.DistributedVariable):
 
   def __init__(self, strategy, values, aggregation, var_policy=None):
     super(DistributedVariableWrapper, self).__init__(strategy, values,
                                                      aggregation, var_policy)
-    self.shadow = values[0]
+    self.shadow = self._get_on_device_or_primary()
 
   def verify_embedding_weights(self, sparse_ids, sparse_weights=None):
-    IEmbeddingVariable.verify_embedding_param_weights(self.shadow.params,
-                                                      sparse_ids,
-                                                      sparse_weights)
+    EmbeddingWeights.verify_embedding_param_weights(self.shadow.params,
+                                                    sparse_ids, sparse_weights)
+
+  def embedding_lookup(self,
+                       ids,
+                       name=None,
+                       max_norm=None) -> (tf.Tensor, EmbeddingWeights):
+    raise NotImplementedError("embedding_lookup is not supported in "
+                              "DistributedVariableWrapper")

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -17,23 +17,15 @@
 Dynamic Embedding is designed for Large-scale Sparse Weights Training.
 See [Sparse Domain Isolation](https://github.com/tensorflow/community/pull/237)
 """
-from tensorflow.python.ops.variables import VariableAggregation
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
-from tensorflow_recommenders_addons.utils.resource_loader import get_tf_version_triple
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import DEResourceVariable
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import IEmbeddingVariable
 
-from tensorflow.core.framework import attr_value_pb2
-try:
-  from tensorflow.python.compat import compat as forward_compat
-except:
-  forward_compat = None
-from tensorflow.python.eager import context
 from tensorflow.python.eager import tape as tape_record
 if not hasattr(tape_record, 'record_operation'):
   # tf version >= 2.13.0
   from tensorflow.python.eager import record as tape_record
-from tensorflow.python.keras.optimizer_v2 import optimizer_v2
-from tensorflow.python.ops import clip_ops
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
@@ -43,12 +35,8 @@ try:  # tf version >= 2.14.0
 except:
   from tensorflow.python.framework.ops import Tensor
 from tensorflow.python.ops import array_ops
-from tensorflow.python.ops import control_flow_ops
-from tensorflow.python.ops import gen_resource_variable_ops
-from tensorflow.python.ops import resource_variable_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import sparse_ops
-from tensorflow.python.ops import variables
 from tensorflow.python.ops import variable_scope
 try:  # tf version >= 2.14.0
   from tensorflow.python.ops.array_ops_stack import stack
@@ -62,640 +50,12 @@ try:  # The data_structures has been moved to the new package in tf 2.11
   from tensorflow.python.trackable import data_structures
 except:
   from tensorflow.python.training.tracking import data_structures
-from tensorflow.python.util import compat, dispatch
 
-from tensorflow.python.keras.utils import tf_utils
 try:  # tf version >= 2.14.0
   from tensorflow.python.distribute import distribute_lib as distribute_ctx
   assert hasattr(distribute_ctx, 'has_strategy')
 except:
   from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
-from tensorflow.python.distribute import values as distribute_values_lib
-from tensorflow.python.training.saving import saveable_object
-from tensorflow.python.distribute import distribute_utils
-
-_ANONYMOUS_TRAINABLE_STORE_KEY = '_anonymous_trainable_store_key'
-
-
-class TrainableWrapperDistributedPolicy(distribute_values_lib.OnWritePolicy):
-
-  def get_saveable(self, var, primary_var, name):
-    for v in var.values:
-      v._gather_saveables_for_checkpoint()
-
-    def tensor():
-      return array_ops.zeros((
-          0,
-          primary_var.params.dim,
-      ),
-                             dtype=primary_var.params.value_dtype)  # pylint: disable=protected-access
-
-    spec = saveable_object.SaveSpec(tensor=tensor,
-                                    slice_spec="",
-                                    name=name,
-                                    dtype=primary_var.params.value_dtype,
-                                    device=primary_var.device)
-    return tensor, [spec]
-
-
-class DistributedVariableWrapper(distribute_values_lib.DistributedVariable):
-
-  def __init__(self, strategy, values, aggregation, var_policy=None):
-    super(DistributedVariableWrapper, self).__init__(strategy, values,
-                                                     aggregation, var_policy)
-
-
-class DEResourceVariable(resource_variable_ops.ResourceVariable):
-
-  def __init__(self, *args, **kwargs):
-    super(DEResourceVariable, self).__init__(*args, **kwargs)
-
-
-class TrainableWrapper(resource_variable_ops.ResourceVariable):
-  """
-    This class is a trainable wrapper of Dynamic Embedding,
-    and the key role is recording the map relation between params and ids.
-    inheriting from the ResourceVariable make it trainable.
-    """
-
-  def __getattribute__(self, name):
-    if name in ["sparse_read", "gather_nd"]:
-      raise AttributeError("no such method: {}".format(name))
-    return super(resource_variable_ops.ResourceVariable,
-                 self).__getattribute__(name)
-
-  def __init__(self, params, ids, max_norm, *args, **kwargs):
-    """Creates an empty `TrainableWrapper` object.©
-
-        Creates a group of tables placed on devices,
-        the type of its keys and values are specified by key_dtype
-        and value_dtype, respectively.
-
-        Args:
-          params: A dynamic_embedding.Variable instance.
-          ids: A tensor with any shape as same dtype of params.key_dtype.
-          max_norm: If not `None`, each values is clipped if its l2-norm is larger
-            than this value.
-          other parameters is same with ResourceVariable.
-        Returns:
-          A `TrainableWrapper` object which is a subclass of ResourceVariable.
-        """
-    self.params = params
-    self.ids = ids
-    self.exists = None
-    self.max_norm = max_norm
-    self.prefetch_values_op = None
-    self.model_mode = kwargs.get("model_mode")
-    kwargs.pop("model_mode")
-    self._tracked_slots = []
-    self._optimizer_vars = data_structures.NoDependency([])
-    super(TrainableWrapper, self).__init__(*args, **kwargs)
-
-  def prefetch_values(self, update=False):
-    if update or (self.prefetch_values_op is None):
-      if self.params.bp_v2:
-        r, self.exists = self.params.lookup(self.ids, return_exists=True)
-        self.prefetch_values_op = self.transform(r)
-      else:
-        self.prefetch_values_op = self.transform(self.params.lookup(self.ids))
-    return self.prefetch_values_op
-
-  def __repr__(self):
-    if context.executing_eagerly() and not self._in_graph_mode:
-      return "<tf.Variable '%s' shape=%s dtype=%s, numpy=%s>" % (
-          self.name, self.get_shape(), self.dtype.name,
-          ops.numpy_text(self.read_value(), is_repr=True))
-    else:
-      return "<tf.Variable '%s' shape=%s dtype=%s>" % (
-          self.name, self.get_shape(), self.dtype.name)
-
-  def _init_from_args(self,
-                      initial_value=None,
-                      trainable=None,
-                      collections=None,
-                      caching_device=None,
-                      name=None,
-                      dtype=None,
-                      constraint=None,
-                      synchronization=None,
-                      aggregation=None,
-                      distribute_strategy=None,
-                      shape=None,
-                      *args,
-                      **kwargs):
-    """Creates a variable.
-
-        Args:
-          initial_value: A `Tensor`, or Python object convertible to a `Tensor`,
-            which is the initial value for the Variable. The initial value must have
-            a shape specified unless `validate_shape` is set to False. Can also be a
-            callable with no argument that returns the initial value when called.
-            (Note that initializer functions from init_ops.py must first be bound
-             to a shape before being used here.)
-          trainable: If `True`, the default, also adds the variable to the graph
-            collection `GraphKeys.TRAINABLE_VARIABLES`. This collection is used as
-            the default list of variables to use by the `Optimizer` classes.
-            Defaults to `True`, unless `synchronization` is set to `ON_READ`, in
-            which case it defaults to `False`.
-          collections: List of graph collections keys. The new variable is added to
-            these collections. Defaults to `[GraphKeys.GLOBAL_VARIABLES]`.
-          caching_device: Optional device string or function describing where the
-            Variable should be cached for reading.  Defaults to the Variable's
-            device.  If not `None`, caches on another device.  Typical use is to
-            cache on the device where the Ops using the Variable reside, to
-            deduplicate copying through `Switch` and other conditional statements.
-          name: Optional name for the variable. Defaults to `'Variable'` and gets
-            uniquified automatically.
-          dtype: If set, initial_value will be converted to the given type.
-            If None, either the datatype will be kept (if initial_value is
-           a Tensor) or float32 will be used (if it is a Python object convertible
-           to a Tensor).
-          constraint: An optional projection function to be applied to the variable
-            after being updated by an `Optimizer` (e.g. used to implement norm
-            constraints or value constraints for layer weights). The function must
-            take as input the unprojected Tensor representing the value of the
-            variable and return the Tensor for the projected value
-            (which must have the same shape). Constraints are not safe to
-            use when doing asynchronous distributed training.
-          synchronization: Indicates when a distributed a variable will be
-            aggregated. Accepted values are constants defined in the class
-            `tf.VariableSynchronization`. By default the synchronization is set to
-            `AUTO` and the current `DistributionStrategy` chooses
-            when to synchronize.
-          aggregation: Indicates how a distributed variable will be aggregated.
-            Accepted values are constants defined in the class
-            `tf.VariableAggregation`.
-          distribute_strategy: DistributionStrategy under which this variable
-            was created.
-          shape: (optional) The shape of this variable. If None, the shape of
-            `initial_value` will be used. When setting this argument to
-            `tf.TensorShape(None)` (representing an unspecified shape), the variable
-            can be assigned with values of different shapes.
-
-        Raises:
-          ValueError: If the initial value is not specified, or does not have a
-            shape and `validate_shape` is `True`.
-
-        @compatibility(eager)
-        When Eager Execution is enabled, variables are never added to collections.
-        It is not implicitly added to the `GLOBAL_VARIABLES` or
-        `TRAINABLE_VARIABLES` collections, and the `collections` argument is
-        ignored.
-        @end_compatibility
-        """
-    (
-        synchronization,
-        aggregation,
-        trainable,
-    ) = variables.validate_synchronization_aggregation_trainable(
-        synchronization, aggregation, trainable, name)
-    if initial_value is None:
-      raise ValueError("initial_value must be specified.")
-    init_from_fn = callable(initial_value)
-
-    if (isinstance(initial_value, Tensor) and hasattr(initial_value, "graph")
-        and initial_value.graph.building_function):
-      raise ValueError("Tensor-typed variable initializers must either be "
-                       "wrapped in an init_scope or callable "
-                       "(e.g., `tf.Variable(lambda : "
-                       "tf.truncated_normal([10, 40]))`) when building "
-                       "functions. Please file a feature request if this "
-                       "restriction inconveniences you.")
-
-    if collections is None:
-      collections = [ops.GraphKeys.GLOBAL_VARIABLES]
-    if not isinstance(collections, (list, tuple, set)):
-      raise ValueError(
-          "collections argument to Variable constructor must be a list, tuple, "
-          "or set. Got %s of type %s" % (collections, type(collections)))
-    if constraint is not None and not callable(constraint):
-      raise ValueError("The `constraint` argument must be a callable.")
-
-    if isinstance(initial_value, trackable.CheckpointInitialValue):
-      self._maybe_initialize_trackable()
-      self._update_uid = initial_value.checkpoint_position.restore_uid
-      initial_value = initial_value.wrapped_value
-
-    if trainable and ops.GraphKeys.TRAINABLE_VARIABLES not in collections:
-      collections = list(collections) + [ops.GraphKeys.TRAINABLE_VARIABLES]
-    with ops.init_scope():
-      self._in_graph_mode = not context.executing_eagerly()
-      with ops.name_scope(name,
-                          "TrainableWrapper",
-                          [] if init_from_fn else [initial_value],
-                          skip_on_eager=False) as name:
-        # pylint: disable=protected-access
-        handle_name = ops.name_from_scope_name(name)
-        handle_name = handle_name or "TrainableWrapperHandle"
-        if self._in_graph_mode:
-          shared_name = handle_name
-          unique_id = shared_name
-        else:
-          # When in eager mode use a uid for the shared_name, to prevent
-          # accidental sharing.
-          unique_id = "%s_%d" % (handle_name, ops.uid())
-          tf_major_version, _, _ = get_tf_version_triple()
-          if int(tf_major_version) >= 2:
-            shared_name = None  # Never shared
-          else:
-            shared_name = context.shared_name()
-        # Use attr_scope and device(None) to simulate the behavior of
-        # colocate_with when the variable we want to colocate with doesn't
-        # yet exist.
-        device_context_manager = (ops.device if self._in_graph_mode else
-                                  ops.NullContextmanager)
-        attr = attr_value_pb2.AttrValue(list=attr_value_pb2.AttrValue.ListValue(
-            s=[compat.as_bytes("loc:@%s" % handle_name)]))
-        with ops.get_default_graph()._attr_scope({"_class": attr}):
-          with ops.name_scope("Initializer"), device_context_manager(None):
-            initial_value = ops.convert_to_tensor(
-                initial_value() if init_from_fn else initial_value,
-                name="initial_value",
-                dtype=dtype,
-            )
-          if shape is None:
-            shape = initial_value.shape
-          handle = resource_variable_ops.eager_safe_variable_handle(
-              initial_value=initial_value,
-              shape=None,  # shape,
-              shared_name=shared_name,
-              name=name,
-              graph_mode=self._in_graph_mode,
-          )
-        # pylint: disable=protected-access
-        if (self._in_graph_mode and initial_value is not None
-            and initial_value.op._get_control_flow_context() is not None):
-          raise ValueError(
-              "Initializer for variable %s is from inside a control-flow "
-              "construct, such as a loop or conditional. When creating a "
-              "variable inside a loop or conditional, use a lambda as the "
-              "initializer." % name)
-        # pylint: enable=protected-access
-        dtype = initial_value.dtype.base_dtype
-
-        if self._in_graph_mode:
-          with ops.name_scope("IsInitialized"):
-            is_initialized_op = (
-                gen_resource_variable_ops.var_is_initialized_op(handle))
-          if initial_value is not None:
-            # pylint: disable=g-backslash-continuation
-            with ops.name_scope("Assign") as n, ops.colocate_with(
-                None, ignore_existing=True), ops.device(handle.device):
-              # pylint: disable=protected-access
-              initializer_op = gen_resource_variable_ops.assign_variable_op(
-                  handle,
-                  variables._try_guard_against_uninitialized_dependencies(
-                      name, initial_value),
-                  name=n,
-              )
-              # pylint: enable=protected-access
-            # pylint: enable=g-backslash-continuation
-          with ops.name_scope("Read"):
-            # Manually assign reads to the handle's device to avoid log
-            # messages.
-            with ops.device(handle.device):
-              with ops.control_dependencies([
-                  gen_resource_variable_ops.assign_variable_op(
-                      handle,
-                      self.prefetch_values(),
-                      name="AssignBeforeInitRead",
-                  )
-              ]):
-                value = gen_resource_variable_ops.read_variable_op(
-                    handle, dtype)
-            graph_element = value
-            if caching_device is not None:
-              # Variables may be created in a tf.device() or ops.colocate_with()
-              # context. At the same time, users would expect caching device to
-              # be independent of this context, and/or would not expect the
-              # current device context to be merged with the caching device
-              # spec.  Therefore we reset the colocation stack before creating
-              # the cached value. Note that resetting the colocation stack will
-              # also reset the device stack.
-              with ops.colocate_with(None, ignore_existing=True):
-                with ops.device(caching_device):
-                  cached_value = array_ops.identity(value)
-            else:
-              cached_value = None
-        else:
-          gen_resource_variable_ops.assign_variable_op(handle, initial_value)
-          is_initialized_op = None
-          initializer_op = None
-          graph_element = None
-          if caching_device:
-            with ops.device(caching_device):
-              with ops.control_dependencies([
-                  gen_resource_variable_ops.assign_variable_op(
-                      handle,
-                      self.prefetch_values(),
-                      name="AssignBeforeInitRead",
-                  )
-              ]):
-                cached_value = (gen_resource_variable_ops.read_variable_op(
-                    handle, dtype))
-          else:
-            cached_value = None
-        if not context.executing_eagerly():
-          # Eager variables are only added to collections if they are part of an
-          # eager variable store (otherwise in an interactive session they would
-          # hog memory and cause OOM). This is done in ops/variable_scope.py.
-          ops.add_to_collections(collections, self)
-        elif ops.GraphKeys.GLOBAL_STEP in collections:
-          ops.add_to_collections(ops.GraphKeys.GLOBAL_STEP, self)
-      initial_value = initial_value if self._in_graph_mode else None
-      super(resource_variable_ops.ResourceVariable, self).__init__(
-          trainable=trainable,
-          shape=shape,
-          dtype=dtype,
-          handle=handle,
-          synchronization=synchronization,
-          constraint=constraint,
-          aggregation=aggregation,
-          distribute_strategy=distribute_strategy,
-          name=name,
-          unique_id=unique_id,
-          handle_name=handle_name,
-          graph_element=graph_element,
-          initial_value=initial_value,
-          initializer_op=initializer_op,
-          is_initialized_op=is_initialized_op,
-          cached_value=cached_value,
-      )
-
-  def update_op(self, v0=None):
-    v1 = self.read_value(False)
-    if self.params.bp_v2:
-      assert v0 is not None
-      update_param_op = self.params.accum(self.ids, v0, v1, self.exists)
-    else:
-      update_param_op = self.params.upsert(self.ids, v1)
-    if self.params.restrict_policy is not None:
-      update_status_op = self.params.restrict_policy.apply_update(self.ids)
-      return control_flow_ops.group([update_param_op, update_status_op])
-    return update_param_op
-
-  def size(self):
-    return self.params.size()
-
-  def _read_variable_op(self, do_prefetch=True, no_copy=False):
-    resource_variable_ops.variable_accessed(self)
-    if no_copy and forward_compat:
-      if forward_compat.forward_compatible(2022, 5, 3):
-        gen_resource_variable_ops.disable_copy_on_read(self.handle)
-    if self.model_mode == "train":
-      if do_prefetch:
-        with ops.control_dependencies([
-            gen_resource_variable_ops.assign_variable_op(
-                self._handle,
-                self.prefetch_values(),
-                name="AssignBeforeReadVariable")
-        ]):
-          _result = gen_resource_variable_ops.read_variable_op(
-              self._handle, self._dtype)
-      else:
-        _result = gen_resource_variable_ops.read_variable_op(
-            self._handle, self._dtype)
-    else:
-      _result = self.prefetch_values()
-
-    if not context.executing_eagerly():
-      # Note that if a control flow context is active the input of the read op
-      # might not actually be the handle. This line bypasses it.
-      tape_record.record_operation("ReadVariableOp", [_result], [self._handle],
-                                   lambda x: [x])
-    result = self.transform(_result)
-    return result
-
-  def read_value(self, do_prefetch=True):
-    """Constructs an op which reads the value of this variable.
-
-        Should be used when there are multiple reads, or when it is desirable to
-        read the value only after some condition is true.
-        Args:
-          do_prefetch: get value from `params` before reading, if True
-
-        Returns:
-         the read operation.
-        """
-    with ops.name_scope("Read"):
-      # Ensure we read the variable in the same device as the handle.
-      with ops.device(self._handle.device):
-        value = self._read_variable_op(do_prefetch)
-    # Return an identity so it can get placed on whatever device the context
-    # specifies instead of the device where the variable is.
-    return array_ops.identity(value)
-
-  @staticmethod
-  def _clip(params, ids, max_norm):
-
-    def _rank(x):
-      rank = ops.convert_to_tensor(x).get_shape().ndims
-      if rank:
-        return rank, True
-      else:
-        return array_ops.rank(x), False
-
-    if max_norm is None:
-      return params
-    ids_rank, ids_static = _rank(ids)
-    params_rank, params_static = _rank(params)
-    return clip_ops.clip_by_norm(
-        params,
-        max_norm,
-        axes=(list(range(ids_rank, params_rank)) if ids_static and params_static
-              else math_ops.range(ids_rank, params_rank)),
-    )
-
-  def transform(self, result):
-    if self.max_norm is not None:
-      result = self._clip(result, self.ids, self.max_norm)
-    return result
-
-  def _track_optimizer_slots(self, slots):
-    if not all(isinstance(s, TrainableWrapper) for s in slots):
-      raise TypeError(
-          'Can only track TrainableWrapper slots, but get {}'.format(
-              [type(s) for s in slots]))
-    identifiers = [optimizer_v2._var_key(s) for s in self._tracked_slots]
-    for s in slots:
-      if optimizer_v2._var_key(s) not in identifiers:
-        self._tracked_slots.append(s)
-
-    if self.params.restrict_policy is not None:
-      self.params.restrict_policy._track_params_from_optimizer_slots(slots)
-
-  def _reset_ids(self, ids):
-    self.ids = ids
-    self.prefetch_values(update=True)
-    for s in self._tracked_slots:
-      s._reset_ids(ids)
-
-
-def embedding_lookup(
-    params,
-    ids,
-    partition_strategy=None,  # pylint: disable=unused-argument
-    name=None,
-    validate_indices=None,  # pylint: disable=unused-argument
-    max_norm=None,
-    return_trainable=False,
-):
-  """Provides a dynamic version of embedding_lookup
-      similar with tf.nn.embedding_lookup.
-
-    Ids are flattened to a 1d tensor before being passed to embedding_lookup
-    then, they are unflattend to match the original ids shape plus an extra
-    leading dimension of the size of the embeddings.
-
-    Args:
-      params: A dynamic_embedding.Variable instance.
-      ids: A tensor with any shape as same dtype of params.key_dtype.
-      partition_strategy: No used, for API compatiblity with `nn.emedding_lookup`.
-      name: A name for the operation. Name is optional in graph mode and required
-        in eager mode.
-      validate_indices: No used, just for compatible with nn.embedding_lookup .
-      max_norm: If not `None`, each embedding is clipped if its l2-norm is larger
-        than this value.
-      return_trainable: optional, If True, also return TrainableWrapper. If in
-        eager mode, it will return a `ShadowVariable`, which is eager derivative of
-        TrainableWrapper. If inside tf.function scope, then set return_trainable
-        is disabled. Please use `dynamic_embedding.Variable.get_trainable_by_name` or
-        `dynamic_embedding.Variable.trainable_store` to get the created trainable
-        shadow inside tf.function scope.
-    Returns:
-      A tensor with shape [shape of ids] + [dim],
-        dim is equal to the value dim of params.
-        containing the values from the params tensor(s) for keys in ids.
-      trainable_wrap:
-        A TrainableWrapper object used to fill the Optimizers `var_list`
-          Only provided if `return_trainable` is True. If in eager mode,
-          it will be a `ShadowVariable`, which is eager derivative of TrainableWrapper.
-    """
-  if isinstance(params, (list, tuple)) and len(params) > 1:
-    raise ValueError("Only one params is allowed.")
-  if isinstance(params, (list, tuple)):
-    params = params[0]
-  if not isinstance(params, de.Variable):
-    raise TypeError("params should be a Variable instance.")
-  if params.key_dtype != ids.dtype:
-    raise TypeError(
-        "params.key_dtype should be same with ids.dtype: {} vs. {}".format(
-            params.key_dtype, ids.dtype))
-  if context.executing_eagerly() and (name is None):
-    raise ValueError(
-        'Must specify a name for dynamic_embedding.embedding_lookup when running '
-        'eagerly. The `de.shadow_ops.embedding_lookup` is recommended in eager case.'
-    )
-
-  scope = variable_scope.get_variable_scope()
-  full_name = scope.name + "/" if scope.name else ""
-  full_name += (name + "/") if name else "embedding_lookup/"
-  with ops.name_scope(full_name):
-    ids = ops.convert_to_tensor(ids, name="ids")
-    if ids.get_shape().is_fully_defined():
-      # use static shape
-      initial_shape = [ids.get_shape().num_elements(), params.dim]
-      embeddings_shape = ids.get_shape().concatenate([params.dim])
-    else:
-      # use dynamic shape
-      initial_shape = (1, params.dim)
-      embeddings_shape = array_ops.concat([array_ops.shape(ids), [params.dim]],
-                                          axis=0)
-    initial_value = array_ops.zeros(shape=initial_shape,
-                                    dtype=params.value_dtype)
-    if (isinstance(initial_value, Tensor) and hasattr(initial_value, "graph")
-        and initial_value.graph.building_function):
-
-      def initial_value():
-        return array_ops.zeros(initial_shape, dtype=params.value_dtype)
-
-    with ops.colocate_with(None, ignore_existing=True):
-      collections = [ops.GraphKeys.LOCAL_VARIABLES]
-      if params.trainable:
-        collections += [ops.GraphKeys.TRAINABLE_VARIABLES]
-
-      def _create_or_get_trainable(trainable_name):
-        if trainable_name is None:
-          if context.executing_eagerly():
-            raise ValueError(
-                'Must provide a name for embedding_lookup when using eager execution.'
-            )
-          trainable_name = ops.get_default_graph().unique_name(
-              _ANONYMOUS_TRAINABLE_STORE_KEY)
-        if not context.executing_eagerly() and not ops.inside_function():
-          wrapper = de.TrainableWrapper(params=params,
-                                        ids=ids,
-                                        max_norm=max_norm,
-                                        initial_value=initial_value,
-                                        dtype=params.value_dtype,
-                                        trainable=params.trainable,
-                                        collections=collections,
-                                        model_mode=ModelMode.CURRENT_SETTING,
-                                        name=trainable_name)
-          params._trainable_store[trainable_name] = wrapper
-          return wrapper
-        else:
-          with ops.init_scope():
-            shadow = params._trainable_store.get(trainable_name, None)
-            if shadow is None:
-              shadow = de.shadow_ops.ShadowVariable(
-                  params,
-                  name=trainable_name,
-                  max_norm=max_norm,
-                  trainable=params.trainable,
-                  model_mode=ModelMode.CURRENT_SETTING)
-              params._trainable_store[trainable_name] = shadow
-          return shadow
-
-      with ops.colocate_with(ids, ignore_existing=True):
-        if distribute_ctx.has_strategy():
-          trainable_ = params._distribute_trainable_store.get(name, None)
-          if trainable_ is None:
-            strategy_devices = distribute_ctx.get_strategy(
-            ).extended.worker_devices
-            trainable_impl = tf_utils.ListWrapper([])
-            for i, strategy_device in enumerate(strategy_devices):
-              with ops.device(strategy_device):
-                name_replica = name
-                if i > 0:
-                  name_replica = "%s/replica_%d" % (name, i)
-                with context.device_policy(context.DEVICE_PLACEMENT_SILENT):
-                  with tape_record.stop_recording():
-                    trainable_impl.as_list().append(
-                        _create_or_get_trainable(name_replica))
-            trainable_ = DistributedVariableWrapper(
-                distribute_ctx.get_strategy(), trainable_impl.as_list(),
-                VariableAggregation.NONE,
-                TrainableWrapperDistributedPolicy(VariableAggregation.NONE))
-            params._distribute_trainable_store[name] = trainable_
-        else:
-          trainable_ = _create_or_get_trainable(name)
-
-      if distribute_utils.is_distributed_variable(trainable_):
-        trainable_device = trainable_._get_on_device_or_primary()
-      else:
-        trainable_device = trainable_
-      if isinstance(trainable_device, de.shadow_ops.ShadowVariable):
-        embeddings = de.shadow_ops.embedding_lookup(
-            trainable_device,
-            ids,
-            partition_strategy=partition_strategy,
-            name=name,
-            validate_indices=validate_indices)
-        if return_trainable:
-          if not context.executing_eagerly():
-            raise NotImplementedError(
-                'return_trainable currently is not implemented when using tf.function.'
-                ' Please use `Variable.trainable_store` or `Variable.get_trainable_by_name`'
-                ' to access the shadow trainable variable if call `embedding_lookup` series'
-                ' APIs inside tf.function scope.')
-          return embeddings, trainable_
-        return embeddings
-
-    embeddings = trainable_
-    embeddings = array_ops.reshape(embeddings, shape=embeddings_shape)
-
-  return (embeddings, trainable_) if return_trainable else embeddings
 
 
 def embedding_lookup_unique(params,
@@ -734,7 +94,7 @@ def embedding_lookup_unique(params,
     ids_flat = array_ops.reshape(ids, math_ops.reduce_prod(shape,
                                                            keepdims=True))
     unique_ids, idx = array_ops.unique(ids_flat)
-    unique_embeddings, trainable_ = embedding_lookup(
+    unique_embeddings, trainable_ = de.embedding_lookup(
         params,
         unique_ids,
         partition_strategy=partition_strategy,
@@ -752,7 +112,7 @@ def embedding_lookup_unique(params,
 
 
 def embedding_lookup_sparse(
-    params,
+    params: IEmbeddingVariable,
     sp_ids,
     sp_weights,
     partition_strategy=None,  # no used
@@ -856,22 +216,10 @@ def embedding_lookup_sparse(
 
     ids = sp_ids.values
     ids, idx = array_ops.unique(ids)
-    if isinstance(params, de.shadow_ops.ShadowVariable):
-      embeddings = de.shadow_ops.embedding_lookup(
-          params,
-          ids,
-          name=name + '/embedding_lookup',
-      )
-      trainable_ = params
-    else:
-      embeddings, trainable_ = embedding_lookup(
-          params,
-          ids,
-          name=name + '/embedding_lookup',
-          partition_strategy=partition_strategy,
-          max_norm=max_norm,
-          return_trainable=True,
-      )
+    embeddings, trainable_ = params.embedding_lookup(ids,
+                                                     name=name,
+                                                     max_norm=max_norm)
+
     if embeddings.dtype in (dtypes.float16, dtypes.bfloat16):
       embeddings = math_ops.cast(embeddings, dtypes.float32)
     if not ignore_weights:
@@ -936,26 +284,8 @@ def embedding_lookup_sparse(
     return (embeddings, trainable_) if return_trainable else embeddings
 
 
-def verify_embedding_weights(embedding_weights,
-                             sparse_ids,
-                             sparse_weights=None):
-  if embedding_weights is None:
-    raise ValueError("Missing embedding_weights %s." % embedding_weights)
-
-  if embedding_weights.key_dtype != sparse_ids.dtype:
-    raise TypeError(
-        "embedding_weights.key_dtype should be same with sparse_ids.dtype: "
-        "{} vs. {}".format(embedding_weights.key_dtype, sparse_ids.dtype))
-
-  weights_dtype = sparse_weights.dtype if sparse_weights is not None else None
-  if weights_dtype and embedding_weights.value_dtype != weights_dtype:
-    raise TypeError(
-        "embedding_weights.value_dtype should be same with sparse_weights.dtype"
-        ": {} vs. {}".format(embedding_weights.value_dtype, weights_dtype))
-
-
 def safe_embedding_lookup_sparse(
-    embedding_weights,
+    embedding_weights: IEmbeddingVariable,
     sparse_ids,
     sparse_weights=None,
     combiner="mean",
@@ -1006,11 +336,7 @@ def safe_embedding_lookup_sparse(
     Raises:
       ValueError: if `embedding_weights` is empty.
   """
-  if isinstance(embedding_weights, de.shadow_ops.ShadowVariable):
-    verify_embedding_weights(embedding_weights.params, sparse_ids,
-                             sparse_weights)
-  else:
-    verify_embedding_weights(embedding_weights, sparse_ids, sparse_weights)
+  embedding_weights.verify_embedding_weights(sparse_ids, sparse_weights)
 
   scope = variable_scope.get_variable_scope()
   full_name = scope.name + "/" + name if scope.name else name
@@ -1101,50 +427,25 @@ def _prune_invalid_weights(sparse_ids, sparse_weights):
   return sparse_ids, sparse_weights
 
 
-class ModelMode(object):
-  """The global config of model modes.
-
-    `TrainableWrapper.read_value` is not thread-safe that causes threads
-    competition and Out-Of-Bound exception in concurrent serving scenario.
-
-    To resolve this, we define the `ModelMode` APIs to instruct
-    the `TrainableWrapper` to build a different thread-safe sub-graph
-    for 'TrainableWrapper.read_value' on inference mode.
-
-    **NOTE** These APIs should be called before any graph are built.
-
-  The following standard modes are defined:
-
-  * `TRAIN`: training/fitting mode.
-  * `INFERENCE`: prediction/inference mode.
-  """
-
-  TRAIN = 'train'
-  INFERENCE = 'inference'
-
-  # The default setting is training mode.
-  CURRENT_SETTING = TRAIN
-
-
 def get_model_mode():
   """ get model mode.
 
   Returns:
     A string: `train` or 'inference'
   """
-  return ModelMode.CURRENT_SETTING
+  return de.ModelMode.CURRENT_SETTING
 
 
 def enable_train_mode():
   """ enable train mode.
   """
-  ModelMode.CURRENT_SETTING = ModelMode.TRAIN
+  de.ModelMode.CURRENT_SETTING = de.ModelMode.TRAIN
 
 
 def enable_inference_mode():
   """ set inference mode.
   """
-  ModelMode.CURRENT_SETTING = ModelMode.INFERENCE
+  de.ModelMode.CURRENT_SETTING = de.ModelMode.INFERENCE
 
 
 def trainable_wrapper_filter(iterable_object_in,
@@ -1153,7 +454,7 @@ def trainable_wrapper_filter(iterable_object_in,
   sparse_grads_and_vars_unaggregated_out = []
   if test_unaggregated_function is None:
     test_unaggregated_function = lambda x: isinstance(
-        x, TrainableWrapper) or isinstance(x, DEResourceVariable)
+        x, de.TrainableWrapper) or isinstance(x, DEResourceVariable)
   for item in iterable_object_in:
     if test_unaggregated_function(item):
       sparse_grads_and_vars_unaggregated_out.append(item)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -20,7 +20,7 @@ See [Sparse Domain Isolation](https://github.com/tensorflow/community/pull/237)
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import DEResourceVariable
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import IEmbeddingVariable
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights
 
 from tensorflow.python.eager import tape as tape_record
 if not hasattr(tape_record, 'record_operation'):
@@ -112,7 +112,7 @@ def embedding_lookup_unique(params,
 
 
 def embedding_lookup_sparse(
-    params: IEmbeddingVariable,
+    params: EmbeddingWeights,
     sp_ids,
     sp_weights,
     partition_strategy=None,  # no used
@@ -132,9 +132,9 @@ def embedding_lookup_sparse(
     is the sum of the size of params along dimension 0.
 
     Args:
-      params: A single `dynamic_embedding.Variable` instance representing
+      params: A single `IEmbeddingVariable`, `dynamic_embedding.Variable` instance representing
         the complete embedding tensor and a new TrainableWrapper will be created and return
-         or a `ShadowVariable` instance, then params will be return without creating a new TrainableWrapper
+         or a `ShadowVariable` / `HvdVariable` instance, then params will be return without creating a new TrainableWrapper
       sp_ids: N x M `SparseTensor` of int64 ids where N is typically batch size
         and M is arbitrary.
       sp_weights: either a `SparseTensor` of float / double weights, or `None` to
@@ -285,7 +285,7 @@ def embedding_lookup_sparse(
 
 
 def safe_embedding_lookup_sparse(
-    embedding_weights: IEmbeddingVariable,
+    embedding_weights: EmbeddingWeights,
     sparse_ids,
     sparse_weights=None,
     combiner="mean",
@@ -308,8 +308,8 @@ def safe_embedding_lookup_sparse(
     along the last dimension.
 
     Args:
-      embedding_weights: A single `dynamic_embedding.Variable` instance
-        representing the complete embedding tensor or a single `ShadowVariable` instance.
+      embedding_weights: A single `IEmbeddingVariable`, either `dynamic_embedding.Variable` or `ShadowVariable`
+       or `HvdVariable` instance representing the complete embedding tensor.
       sparse_ids: `SparseTensor` of shape `[d_0, d_1, ..., d_n]` containing the
         ids. `d_0` is typically batch size.
       sparse_weights: `SparseTensor` of same shape as `sparse_ids`, containing

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -24,7 +24,7 @@ import typing
 import tensorflow as tf
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import IEmbeddingVariable
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights
 from tensorflow_recommenders_addons.utils.check_platform import is_macos, is_arm64
 
 try:  # tf version >= 2.14.0
@@ -454,7 +454,7 @@ class GraphKeys(object):
   TRAINABLE_DYNAMIC_EMBEDDING_VARIABLES = "trainable_dynamic_embedding_variables"
 
 
-class Variable(IEmbeddingVariable, base.Trackable):
+class Variable(EmbeddingWeights, base.Trackable):
   """
   A Distributed version of HashTable(reference from lookup_ops.MutableHashTable)
   It is designed to dynamically store the Sparse Weights(Parameters) of DLRMs.
@@ -666,13 +666,13 @@ class Variable(IEmbeddingVariable, base.Trackable):
               self, self.name)
 
   def verify_embedding_weights(self, sparse_ids, sparse_weights=None):
-    IEmbeddingVariable.verify_embedding_param_weights(self, sparse_ids,
-                                                      sparse_weights)
+    EmbeddingWeights.verify_embedding_param_weights(self, sparse_ids,
+                                                    sparse_weights)
 
   def embedding_lookup(self,
                        ids,
                        name=None,
-                       max_norm=None) -> (tf.Tensor, IEmbeddingVariable):
+                       max_norm=None) -> (tf.Tensor, EmbeddingWeights):
     return embedding_lookup(
         self,
         ids,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/embedding_variable.py
@@ -1,0 +1,538 @@
+import abc
+import tensorflow as tf
+from tensorflow.core.framework import attr_value_pb2
+
+from tensorflow_recommenders_addons.utils.resource_loader import get_tf_version_triple
+try:
+  from tensorflow.python.compat import compat as forward_compat
+except:
+  forward_compat = None
+from tensorflow.python.eager import context
+from tensorflow.python.eager import tape as tape_record
+if not hasattr(tape_record, 'record_operation'):
+  # tf version >= 2.13.0
+  from tensorflow.python.eager import record as tape_record
+from tensorflow.python.keras.optimizer_v2 import optimizer_v2
+from tensorflow.python.ops import clip_ops
+from tensorflow.python.framework import ops
+
+try:  # tf version >= 2.14.0
+  from tensorflow.python.framework.tensor import Tensor
+except:
+  from tensorflow.python.framework.ops import Tensor
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import control_flow_ops
+from tensorflow.python.ops import gen_resource_variable_ops
+from tensorflow.python.ops import resource_variable_ops
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import variables
+try:  # tf version >= 2.14.0
+  from tensorflow.python.ops.array_ops_stack import stack
+except:
+  from tensorflow.python.ops.array_ops import stack
+try:  # tf version >= 2.10.0
+  from tensorflow.python.trackable import base as trackable
+except:
+  from tensorflow.python.training.tracking import base as trackable
+try:  # The data_structures has been moved to the new package in tf 2.11
+  from tensorflow.python.trackable import data_structures
+except:
+  from tensorflow.python.training.tracking import data_structures
+from tensorflow.python.util import compat, dispatch
+
+try:  # tf version >= 2.14.0
+  from tensorflow.python.distribute import distribute_lib as distribute_ctx
+  assert hasattr(distribute_ctx, 'has_strategy')
+except:
+  from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
+
+
+class IEmbeddingVariable(abc.ABC):
+
+  @abc.abstractmethod
+  def verify_embedding_weights(self, sparse_ids, sparse_weights=None):
+    raise NotImplementedError
+
+  @abc.abstractmethod
+  def embedding_lookup(self,
+                       ids,
+                       name=None,
+                       max_norm=None) -> (tf.Tensor, "IEmbeddingVariable"):
+    """
+    embedding lookup, and store the result. No by-product will
+    be introduced in this call. So it can be decorated by `tf.function`.
+
+    Args:
+      shadow: A ShadowVariable object.
+      ids: A tensor with any shape as same dtype of params.key_dtype.
+      name: A name for the operation.
+
+    Returns:
+      A tensor with shape [shape of ids] + [dim],
+        dim is equal to the value dim of params.
+        containing the values from the params tensor(s) for keys in ids.
+    """
+    raise NotImplementedError
+
+  @staticmethod
+  def verify_embedding_param_weights(embedding_weights,
+                                     sparse_ids,
+                                     sparse_weights=None):
+    if embedding_weights is None:
+      raise ValueError("Missing embedding_weights %s." % embedding_weights)
+
+    if embedding_weights.key_dtype != sparse_ids.dtype:
+      raise TypeError(
+          "embedding_weights.key_dtype should be same with sparse_ids.dtype: "
+          "{} vs. {}".format(embedding_weights.key_dtype, sparse_ids.dtype))
+
+    weights_dtype = sparse_weights.dtype if sparse_weights is not None else None
+    if weights_dtype and embedding_weights.value_dtype != weights_dtype:
+      raise TypeError(
+          "embedding_weights.value_dtype should be same with sparse_weights.dtype"
+          ": {} vs. {}".format(embedding_weights.value_dtype, weights_dtype))
+
+
+class ModelMode(object):
+  """The global config of model modes.
+
+    `TrainableWrapper.read_value` is not thread-safe that causes threads
+    competition and Out-Of-Bound exception in concurrent serving scenario.
+
+    To resolve this, we define the `ModelMode` APIs to instruct
+    the `TrainableWrapper` to build a different thread-safe sub-graph
+    for 'TrainableWrapper.read_value' on inference mode.
+
+    **NOTE** These APIs should be called before any graph are built.
+
+  The following standard modes are defined:
+
+  * `TRAIN`: training/fitting mode.
+  * `INFERENCE`: prediction/inference mode.
+  """
+
+  TRAIN = 'train'
+  INFERENCE = 'inference'
+
+  # The default setting is training mode.
+  CURRENT_SETTING = TRAIN
+
+
+class TrainableWrapper(resource_variable_ops.ResourceVariable):
+  """
+    This class is a trainable wrapper of Dynamic Embedding,
+    and the key role is recording the map relation between params and ids.
+    inheriting from the ResourceVariable make it trainable.
+    """
+
+  def __getattribute__(self, name):
+    if name in ["sparse_read", "gather_nd"]:
+      raise AttributeError("no such method: {}".format(name))
+    return super(resource_variable_ops.ResourceVariable,
+                 self).__getattribute__(name)
+
+  def __init__(self, params, ids, max_norm, *args, **kwargs):
+    """Creates an empty `TrainableWrapper` object.©
+
+        Creates a group of tables placed on devices,
+        the type of its keys and values are specified by key_dtype
+        and value_dtype, respectively.
+
+        Args:
+          params: A dynamic_embedding.Variable instance.
+          ids: A tensor with any shape as same dtype of params.key_dtype.
+          max_norm: If not `None`, each values is clipped if its l2-norm is larger
+            than this value.
+          other parameters is same with ResourceVariable.
+        Returns:
+          A `TrainableWrapper` object which is a subclass of ResourceVariable.
+        """
+    self.params = params
+    self.ids = ids
+    self.exists = None
+    self.max_norm = max_norm
+    self.prefetch_values_op = None
+    self.model_mode = kwargs.get("model_mode")
+    kwargs.pop("model_mode")
+    self._tracked_slots = []
+    self._optimizer_vars = data_structures.NoDependency([])
+    super(TrainableWrapper, self).__init__(*args, **kwargs)
+
+  def prefetch_values(self, update=False):
+    if update or (self.prefetch_values_op is None):
+      if self.params.bp_v2:
+        r, self.exists = self.params.lookup(self.ids, return_exists=True)
+        self.prefetch_values_op = self.transform(r)
+      else:
+        self.prefetch_values_op = self.transform(self.params.lookup(self.ids))
+    return self.prefetch_values_op
+
+  def __repr__(self):
+    if context.executing_eagerly() and not self._in_graph_mode:
+      return "<tf.Variable '%s' shape=%s dtype=%s, numpy=%s>" % (
+          self.name, self.get_shape(), self.dtype.name,
+          ops.numpy_text(self.read_value(), is_repr=True))
+    else:
+      return "<tf.Variable '%s' shape=%s dtype=%s>" % (
+          self.name, self.get_shape(), self.dtype.name)
+
+  def _init_from_args(self,
+                      initial_value=None,
+                      trainable=None,
+                      collections=None,
+                      caching_device=None,
+                      name=None,
+                      dtype=None,
+                      constraint=None,
+                      synchronization=None,
+                      aggregation=None,
+                      distribute_strategy=None,
+                      shape=None,
+                      *args,
+                      **kwargs):
+    """Creates a variable.
+
+        Args:
+          initial_value: A `Tensor`, or Python object convertible to a `Tensor`,
+            which is the initial value for the Variable. The initial value must have
+            a shape specified unless `validate_shape` is set to False. Can also be a
+            callable with no argument that returns the initial value when called.
+            (Note that initializer functions from init_ops.py must first be bound
+             to a shape before being used here.)
+          trainable: If `True`, the default, also adds the variable to the graph
+            collection `GraphKeys.TRAINABLE_VARIABLES`. This collection is used as
+            the default list of variables to use by the `Optimizer` classes.
+            Defaults to `True`, unless `synchronization` is set to `ON_READ`, in
+            which case it defaults to `False`.
+          collections: List of graph collections keys. The new variable is added to
+            these collections. Defaults to `[GraphKeys.GLOBAL_VARIABLES]`.
+          caching_device: Optional device string or function describing where the
+            Variable should be cached for reading.  Defaults to the Variable's
+            device.  If not `None`, caches on another device.  Typical use is to
+            cache on the device where the Ops using the Variable reside, to
+            deduplicate copying through `Switch` and other conditional statements.
+          name: Optional name for the variable. Defaults to `'Variable'` and gets
+            uniquified automatically.
+          dtype: If set, initial_value will be converted to the given type.
+            If None, either the datatype will be kept (if initial_value is
+           a Tensor) or float32 will be used (if it is a Python object convertible
+           to a Tensor).
+          constraint: An optional projection function to be applied to the variable
+            after being updated by an `Optimizer` (e.g. used to implement norm
+            constraints or value constraints for layer weights). The function must
+            take as input the unprojected Tensor representing the value of the
+            variable and return the Tensor for the projected value
+            (which must have the same shape). Constraints are not safe to
+            use when doing asynchronous distributed training.
+          synchronization: Indicates when a distributed a variable will be
+            aggregated. Accepted values are constants defined in the class
+            `tf.VariableSynchronization`. By default the synchronization is set to
+            `AUTO` and the current `DistributionStrategy` chooses
+            when to synchronize.
+          aggregation: Indicates how a distributed variable will be aggregated.
+            Accepted values are constants defined in the class
+            `tf.VariableAggregation`.
+          distribute_strategy: DistributionStrategy under which this variable
+            was created.
+          shape: (optional) The shape of this variable. If None, the shape of
+            `initial_value` will be used. When setting this argument to
+            `tf.TensorShape(None)` (representing an unspecified shape), the variable
+            can be assigned with values of different shapes.
+
+        Raises:
+          ValueError: If the initial value is not specified, or does not have a
+            shape and `validate_shape` is `True`.
+
+        @compatibility(eager)
+        When Eager Execution is enabled, variables are never added to collections.
+        It is not implicitly added to the `GLOBAL_VARIABLES` or
+        `TRAINABLE_VARIABLES` collections, and the `collections` argument is
+        ignored.
+        @end_compatibility
+        """
+    (
+        synchronization,
+        aggregation,
+        trainable,
+    ) = variables.validate_synchronization_aggregation_trainable(
+        synchronization, aggregation, trainable, name)
+    if initial_value is None:
+      raise ValueError("initial_value must be specified.")
+    init_from_fn = callable(initial_value)
+
+    if (isinstance(initial_value, Tensor) and hasattr(initial_value, "graph")
+        and initial_value.graph.building_function):
+      raise ValueError("Tensor-typed variable initializers must either be "
+                       "wrapped in an init_scope or callable "
+                       "(e.g., `tf.Variable(lambda : "
+                       "tf.truncated_normal([10, 40]))`) when building "
+                       "functions. Please file a feature request if this "
+                       "restriction inconveniences you.")
+
+    if collections is None:
+      collections = [ops.GraphKeys.GLOBAL_VARIABLES]
+    if not isinstance(collections, (list, tuple, set)):
+      raise ValueError(
+          "collections argument to Variable constructor must be a list, tuple, "
+          "or set. Got %s of type %s" % (collections, type(collections)))
+    if constraint is not None and not callable(constraint):
+      raise ValueError("The `constraint` argument must be a callable.")
+
+    if isinstance(initial_value, trackable.CheckpointInitialValue):
+      self._maybe_initialize_trackable()
+      self._update_uid = initial_value.checkpoint_position.restore_uid
+      initial_value = initial_value.wrapped_value
+
+    if trainable and ops.GraphKeys.TRAINABLE_VARIABLES not in collections:
+      collections = list(collections) + [ops.GraphKeys.TRAINABLE_VARIABLES]
+    with ops.init_scope():
+      self._in_graph_mode = not context.executing_eagerly()
+      with ops.name_scope(name,
+                          "TrainableWrapper",
+                          [] if init_from_fn else [initial_value],
+                          skip_on_eager=False) as name:
+        # pylint: disable=protected-access
+        handle_name = ops.name_from_scope_name(name)
+        handle_name = handle_name or "TrainableWrapperHandle"
+        if self._in_graph_mode:
+          shared_name = handle_name
+          unique_id = shared_name
+        else:
+          # When in eager mode use a uid for the shared_name, to prevent
+          # accidental sharing.
+          unique_id = "%s_%d" % (handle_name, ops.uid())
+          tf_major_version, _, _ = get_tf_version_triple()
+          if int(tf_major_version) >= 2:
+            shared_name = None  # Never shared
+          else:
+            shared_name = context.shared_name()
+        # Use attr_scope and device(None) to simulate the behavior of
+        # colocate_with when the variable we want to colocate with doesn't
+        # yet exist.
+        device_context_manager = (ops.device if self._in_graph_mode else
+                                  ops.NullContextmanager)
+        attr = attr_value_pb2.AttrValue(list=attr_value_pb2.AttrValue.ListValue(
+            s=[compat.as_bytes("loc:@%s" % handle_name)]))
+        with ops.get_default_graph()._attr_scope({"_class": attr}):
+          with ops.name_scope("Initializer"), device_context_manager(None):
+            initial_value = ops.convert_to_tensor(
+                initial_value() if init_from_fn else initial_value,
+                name="initial_value",
+                dtype=dtype,
+            )
+          if shape is None:
+            shape = initial_value.shape
+          handle = resource_variable_ops.eager_safe_variable_handle(
+              initial_value=initial_value,
+              shape=None,  # shape,
+              shared_name=shared_name,
+              name=name,
+              graph_mode=self._in_graph_mode,
+          )
+        # pylint: disable=protected-access
+        if (self._in_graph_mode and initial_value is not None
+            and initial_value.op._get_control_flow_context() is not None):
+          raise ValueError(
+              "Initializer for variable %s is from inside a control-flow "
+              "construct, such as a loop or conditional. When creating a "
+              "variable inside a loop or conditional, use a lambda as the "
+              "initializer." % name)
+        # pylint: enable=protected-access
+        dtype = initial_value.dtype.base_dtype
+
+        if self._in_graph_mode:
+          with ops.name_scope("IsInitialized"):
+            is_initialized_op = (
+                gen_resource_variable_ops.var_is_initialized_op(handle))
+          if initial_value is not None:
+            # pylint: disable=g-backslash-continuation
+            with ops.name_scope("Assign") as n, ops.colocate_with(
+                None, ignore_existing=True), ops.device(handle.device):
+              # pylint: disable=protected-access
+              initializer_op = gen_resource_variable_ops.assign_variable_op(
+                  handle,
+                  variables._try_guard_against_uninitialized_dependencies(
+                      name, initial_value),
+                  name=n,
+              )
+              # pylint: enable=protected-access
+            # pylint: enable=g-backslash-continuation
+          with ops.name_scope("Read"):
+            # Manually assign reads to the handle's device to avoid log
+            # messages.
+            with ops.device(handle.device):
+              with ops.control_dependencies([
+                  gen_resource_variable_ops.assign_variable_op(
+                      handle,
+                      self.prefetch_values(),
+                      name="AssignBeforeInitRead",
+                  )
+              ]):
+                value = gen_resource_variable_ops.read_variable_op(
+                    handle, dtype)
+            graph_element = value
+            if caching_device is not None:
+              # Variables may be created in a tf.device() or ops.colocate_with()
+              # context. At the same time, users would expect caching device to
+              # be independent of this context, and/or would not expect the
+              # current device context to be merged with the caching device
+              # spec.  Therefore we reset the colocation stack before creating
+              # the cached value. Note that resetting the colocation stack will
+              # also reset the device stack.
+              with ops.colocate_with(None, ignore_existing=True):
+                with ops.device(caching_device):
+                  cached_value = array_ops.identity(value)
+            else:
+              cached_value = None
+        else:
+          gen_resource_variable_ops.assign_variable_op(handle, initial_value)
+          is_initialized_op = None
+          initializer_op = None
+          graph_element = None
+          if caching_device:
+            with ops.device(caching_device):
+              with ops.control_dependencies([
+                  gen_resource_variable_ops.assign_variable_op(
+                      handle,
+                      self.prefetch_values(),
+                      name="AssignBeforeInitRead",
+                  )
+              ]):
+                cached_value = (gen_resource_variable_ops.read_variable_op(
+                    handle, dtype))
+          else:
+            cached_value = None
+        if not context.executing_eagerly():
+          # Eager variables are only added to collections if they are part of an
+          # eager variable store (otherwise in an interactive session they would
+          # hog memory and cause OOM). This is done in ops/variable_scope.py.
+          ops.add_to_collections(collections, self)
+        elif ops.GraphKeys.GLOBAL_STEP in collections:
+          ops.add_to_collections(ops.GraphKeys.GLOBAL_STEP, self)
+      initial_value = initial_value if self._in_graph_mode else None
+      super(resource_variable_ops.ResourceVariable, self).__init__(
+          trainable=trainable,
+          shape=shape,
+          dtype=dtype,
+          handle=handle,
+          synchronization=synchronization,
+          constraint=constraint,
+          aggregation=aggregation,
+          distribute_strategy=distribute_strategy,
+          name=name,
+          unique_id=unique_id,
+          handle_name=handle_name,
+          graph_element=graph_element,
+          initial_value=initial_value,
+          initializer_op=initializer_op,
+          is_initialized_op=is_initialized_op,
+          cached_value=cached_value,
+      )
+
+  def update_op(self, v0=None):
+    v1 = self.read_value(False)
+    if self.params.bp_v2:
+      assert v0 is not None
+      update_param_op = self.params.accum(self.ids, v0, v1, self.exists)
+    else:
+      update_param_op = self.params.upsert(self.ids, v1)
+    if self.params.restrict_policy is not None:
+      update_status_op = self.params.restrict_policy.apply_update(self.ids)
+      return control_flow_ops.group([update_param_op, update_status_op])
+    return update_param_op
+
+  def size(self):
+    return self.params.size()
+
+  def _read_variable_op(self, do_prefetch=True, no_copy=False):
+    resource_variable_ops.variable_accessed(self)
+    if no_copy and forward_compat:
+      if forward_compat.forward_compatible(2022, 5, 3):
+        gen_resource_variable_ops.disable_copy_on_read(self.handle)
+    if self.model_mode == "train":
+      if do_prefetch:
+        with ops.control_dependencies([
+            gen_resource_variable_ops.assign_variable_op(
+                self._handle,
+                self.prefetch_values(),
+                name="AssignBeforeReadVariable")
+        ]):
+          _result = gen_resource_variable_ops.read_variable_op(
+              self._handle, self._dtype)
+      else:
+        _result = gen_resource_variable_ops.read_variable_op(
+            self._handle, self._dtype)
+    else:
+      _result = self.prefetch_values()
+
+    if not context.executing_eagerly():
+      # Note that if a control flow context is active the input of the read op
+      # might not actually be the handle. This line bypasses it.
+      tape_record.record_operation("ReadVariableOp", [_result], [self._handle],
+                                   lambda x: [x])
+    result = self.transform(_result)
+    return result
+
+  def read_value(self, do_prefetch=True):
+    """Constructs an op which reads the value of this variable.
+
+        Should be used when there are multiple reads, or when it is desirable to
+        read the value only after some condition is true.
+        Args:
+          do_prefetch: get value from `params` before reading, if True
+
+        Returns:
+         the read operation.
+        """
+    with ops.name_scope("Read"):
+      # Ensure we read the variable in the same device as the handle.
+      with ops.device(self._handle.device):
+        value = self._read_variable_op(do_prefetch)
+    # Return an identity so it can get placed on whatever device the context
+    # specifies instead of the device where the variable is.
+    return array_ops.identity(value)
+
+  @staticmethod
+  def _clip(params, ids, max_norm):
+
+    def _rank(x):
+      rank = ops.convert_to_tensor(x).get_shape().ndims
+      if rank:
+        return rank, True
+      else:
+        return array_ops.rank(x), False
+
+    if max_norm is None:
+      return params
+    ids_rank, ids_static = _rank(ids)
+    params_rank, params_static = _rank(params)
+    return clip_ops.clip_by_norm(
+        params,
+        max_norm,
+        axes=(list(range(ids_rank, params_rank)) if ids_static and params_static
+              else math_ops.range(ids_rank, params_rank)),
+    )
+
+  def transform(self, result):
+    if self.max_norm is not None:
+      result = self._clip(result, self.ids, self.max_norm)
+    return result
+
+  def _track_optimizer_slots(self, slots):
+    if not all(isinstance(s, TrainableWrapper) for s in slots):
+      raise TypeError(
+          'Can only track TrainableWrapper slots, but get {}'.format(
+              [type(s) for s in slots]))
+    identifiers = [optimizer_v2._var_key(s) for s in self._tracked_slots]
+    for s in slots:
+      if optimizer_v2._var_key(s) not in identifiers:
+        self._tracked_slots.append(s)
+
+    if self.params.restrict_policy is not None:
+      self.params.restrict_policy._track_params_from_optimizer_slots(slots)
+
+  def _reset_ids(self, ids):
+    self.ids = ids
+    self.prefetch_values(update=True)
+    for s in self._tracked_slots:
+      s._reset_ids(ids)

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/embedding_weights.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/embedding_weights.py
@@ -47,7 +47,7 @@ except:
   from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
 
 
-class IEmbeddingVariable(abc.ABC):
+class EmbeddingWeights(abc.ABC):
 
   @abc.abstractmethod
   def verify_embedding_weights(self, sparse_ids, sparse_weights=None):
@@ -57,7 +57,7 @@ class IEmbeddingVariable(abc.ABC):
   def embedding_lookup(self,
                        ids,
                        name=None,
-                       max_norm=None) -> (tf.Tensor, "IEmbeddingVariable"):
+                       max_norm=None) -> (tf.Tensor, "EmbeddingWeights"):
     """
     embedding lookup, and store the result. No by-product will
     be introduced in this call. So it can be decorated by `tf.function`.

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/ragged_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/ragged_embedding_ops.py
@@ -4,7 +4,7 @@ from tensorflow.python.ops import resource_variable_ops, array_ops, math_ops, ge
 from tensorflow.python.ops.bincount_ops import validate_dense_weights
 from tensorflow.python.ops.ragged import ragged_tensor, ragged_array_ops
 
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_variable import IEmbeddingVariable
+from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import ShadowVariable
 
 
@@ -141,14 +141,6 @@ def _embedding_lookup_sparse_impl(
 
   ids, idx = array_ops.unique(ids)
   embeddings, _ = params.embedding_lookup(ids, name=name)
-  # if isinstance(params, de.shadow_ops.ShadowVariable):
-  #   embeddings = de.shadow_ops.embedding_lookup(params, ids)
-  # else:
-  #   if context.executing_eagerly():
-  #     embeddings = de.embedding_lookup(params, ids, name=name)
-  #   else:
-  #     embeddings = de.embedding_lookup(params, ids)
-
   if not ignore_weights:
     if segment_ids.dtype != dtypes.int32:
       segment_ids = math_ops.cast(segment_ids, dtypes.int32)
@@ -333,7 +325,7 @@ def embedding_lookup_sparse(
 
 
 def safe_embedding_lookup_sparse(
-    embedding_weights: IEmbeddingVariable,
+    embedding_weights: EmbeddingWeights,
     sparse_ids: ragged_tensor.Ragged,
     sparse_weights=None,
     combiner="mean",

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_save_restore_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_save_restore_patch.py
@@ -20,7 +20,6 @@ import os.path
 import re
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import TrainableWrapper, DEResourceVariable
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable \
   import load_de_variable_from_file_system
 
@@ -31,17 +30,14 @@ except:
 from tensorflow.core.protobuf import saver_pb2
 from tensorflow.python.client import session
 from tensorflow.python.eager import context
-from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import errors
 from tensorflow.python.framework import ops
 from tensorflow.python.keras.saving.saved_model import save as tf_saved_model_save
 from tensorflow.python.keras.utils import tf_utils
-from tensorflow.python.lib.io import file_io
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import io_ops
-from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import string_ops
 from tensorflow.python.platform import gfile
 from tensorflow.python.platform import tf_logging
@@ -300,8 +296,9 @@ class _DynamicEmbeddingSaver(saver.Saver):
 
   def _build(self, checkpoint_path, build_save, build_restore):
     # TrainableWrapper and DEResourceVariable should not be save or restore parameter.
-    filter_lambda = lambda x: (isinstance(x, TrainableWrapper)) or (isinstance(
-        x, DEResourceVariable))
+    from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import DEResourceVariable
+    filter_lambda = lambda x: (isinstance(x, de.TrainableWrapper)) or (
+        isinstance(x, DEResourceVariable))
     if isinstance(self._var_list, dict):
       for key, value in self._var_list.items():
         if filter_lambda(value):

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/train/checkpoint.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/train/checkpoint.py
@@ -15,12 +15,8 @@
 # lint-as: python3
 
 import os.path
-import re
-
-from tensorflow_recommenders_addons import dynamic_embedding as de
-from tensorflow_recommenders_addons.dynamic_embedding.python.keras.layers import HvdAllToAllEmbedding
-from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_ops import TrainableWrapper, DEResourceVariable
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_save_restore_patch import de_fs_saveable_class_names, de_fs_sub_saveable_class_names
+from tensorflow_recommenders_addons import dynamic_embedding as de
 
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
@@ -33,6 +29,7 @@ except:
   from tensorflow.python.training.tracking import base as ckpt_base
 from tensorflow.python.lib.io import file_io
 from tensorflow.python.platform import tf_logging
+from tensorflow.python.framework import dtypes
 
 
 class DECheckpoint(TFCheckpoint):
@@ -90,7 +87,7 @@ class DECheckpoint(TFCheckpoint):
   def _de_handle_root_and_var_with_func(self, de_dir: str, func):
 
     def _filter_de_tw(var):
-      if not hasattr(var, "params") or not isinstance(var, TrainableWrapper):
+      if not hasattr(var, "params") or not isinstance(var, de.TrainableWrapper):
         return False
       if not hasattr(var.params, "saveable"):
         return False

--- a/tools/docker/build_wheel.Dockerfile
+++ b/tools/docker/build_wheel.Dockerfile
@@ -37,6 +37,10 @@ ARG PROTOBUF_VERSION
 RUN python -m pip install --upgrade pip
 RUN python -m pip install --default-timeout=1000 $TF_NAME==$TF_VERSION
 
+RUN if [ "$TF_VERSION" = "2.11.0" ] && ([ "$PY_VERSION" = "3.9" ] || [ "$PY_VERSION" = "3.10" ]); then \
+        pip install numpy==1.26.4 --force-reinstall; \
+    fi
+
 COPY tools/docker/install/install_horovod.sh /install/
 RUN /install/install_horovod.sh $HOROVOD_VERSION
 
@@ -103,7 +107,12 @@ RUN python -m pip install --upgrade protobuf==$PROTOBUF_VERSION
 COPY --from=make_wheel /recommenders-addons/wheelhouse/ /recommenders-addons/wheelhouse/
 RUN pip install /recommenders-addons/wheelhouse/*.whl
 
+RUN PYTHON_VERSION=$(python -V | cut -d' ' -f2 | cut -d'.' -f1,2) && \
+    if [ "$TF_VERSION" = "2.11.0" ] && ([ "$PYTHON_VERSION" = "3.9" ] || [ "$PYTHON_VERSION" = "3.10" ]); then \
+        pip install numpy==1.26.4 --force-reinstall; \
+    fi
 RUN python -c "import tensorflow_recommenders_addons as tfra; print(tfra.register_all())"
+
 
 # -------------------------------------------------------------------
 FROM scratch as output


### PR DESCRIPTION
# Description
support ragged tensor in all2all HvdAllToAllEmbedding lookup  
refactor embedding variable, introduce embedding_weights interface so that  dynamic embedding variable, shadow variable, hvd variable can be easily supported in the lookup and safe_embedding_lookup_sparse

Brief Description of the PR:

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
