### PR TITLE
[Feat] Add new setting num_of_buckets_per_alloc from HKV bata 12.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,9 +57,9 @@ http_archive(
 http_archive(
     name = "hkv",
     build_file = "//build_deps/toolchains/hkv:hkv.BUILD",
-    sha256 = "0535477e7cd82affa940468647c07caacd54d42a2c775cfdf199b3aa6e4f87a6",
-    strip_prefix = "HierarchicalKV-0.1.0-beta.11",
-    url = "https://github.com/NVIDIA-Merlin/HierarchicalKV/archive/refs/tags/v0.1.0-beta.11.tar.gz",
+    sha256 = "a73d7bea159173db2038f7c5215a7d1fbd5362adfb232fabde206dc64a1e817c",
+    strip_prefix = "HierarchicalKV-0.1.0-beta.12",
+    url = "https://github.com/NVIDIA-Merlin/HierarchicalKV/archive/refs/tags/v0.1.0-beta.12.tar.gz",
 )
 
 tf_configure(

--- a/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
+++ b/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
@@ -184,6 +184,25 @@ def embedding_out_split(embedding_out_concat, input_split_dims):
   return embedding_out
 
 
+class Bucketize(tf.keras.layers.Layer):
+
+  def __init__(self, boundaries, **kwargs):
+    self.boundaries = boundaries
+    super(Bucketize, self).__init__(**kwargs)
+
+  def build(self, input_shape):
+    # Be sure to call this somewhere!
+    super(Bucketize, self).build(input_shape)
+
+  def call(self, x, **kwargs):
+    return tf.raw_ops.Bucketize(input=x, boundaries=self.boundaries)
+
+  def get_config(self,):
+    config = {'boundaries': self.boundaries}
+    base_config = super(Bucketize, self).get_config()
+    return dict(list(base_config.items()) + list(config.items()))
+
+
 class ChannelEmbeddingLayers(tf.keras.layers.Layer):
 
   def __init__(self,

--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/lookup_impl/lookup_table_op_hkv.h
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/lookup_impl/lookup_table_op_hkv.h
@@ -472,6 +472,20 @@ class TableWrapper {
     }
     step_per_epoch_ = init_options.step_per_epoch;
     mkv_options_.reserved_key_start_bit = init_options.reserved_key_start_bit;
+    static constexpr size_t default_chunk_buckets = 512;
+    size_t min_chunk_buckets = 1;
+    for (size_t pow_n = 1; pow_n <= 63; ++pow_n) {
+      if (mkv_options_.max_bucket_size * (1 << pow_n) >
+          mkv_options_.init_capacity) {
+        min_chunk_buckets = 1 << (pow_n - 1);
+        break;
+      }
+    }
+    mkv_options_.num_of_buckets_per_alloc =
+        mkv_options_.init_capacity >
+                (mkv_options_.max_bucket_size * default_chunk_buckets)
+            ? default_chunk_buckets
+            : min_chunk_buckets;
     curr_epoch_ = 0;
     curr_step_ = 1;
 


### PR DESCRIPTION
# Description

## What's new 
Add new setting num_of_buckets_per_alloc from HKV bata 12. It might improve performance of memory access. And this feature also reduce unessential BFC reallocating information to user when CUDA OOM.
Try to prevent billion of HKV buckets allocating small piece memory which may make BFC allocator re-chunk frequently.
In beta 11, it might print more than 10,000 info. For now, only about 1,000.

## Why choose 512 
According to https://developer.nvidia.com/blog/improving-gpu-memory-oversubscription-performance/, 
which said "_In our experiments, a memory page is set to be 2 MB, which is the largest page size at which GPU MMU can operate._" and "_128-byte aligned access ensures that the CPU-GPU link and system DRAM are used efficiently._ "
And one bucket in HKV is 2048+128 bytes. So a simple calculation, **2MB/(2048+128)B=963.76~=512**. We choose 512 as a default  num_of_buckets_per_alloc.

BFC allocator would create massive information like these:
> 2024-06-04 00:47:52.356200: I tensorflow/core/common_runtime/bfc_allocator.cc:1083] InUse at 7fad2d827a00 of size 2304 next 24266
2024-06-04 00:47:52.356203: I tensorflow/core/common_runtime/bfc_allocator.cc:1083] InUse at 7fad2d828300 of size 2304 next 24267
2024-06-04 00:47:52.356207: I tensorflow/core/common_runtime/bfc_allocator.cc:1083] InUse at 7fad2d828c00 of size 2304 next 24268
2024-06-04 00:47:52.356210: I tensorflow/core/common_runtime/bfc_allocator.cc:1083] InUse at 7fad2d829500 of size 2304 next 24269
2024-06-04 00:47:52.356214: I tensorflow/core/common_runtime/bfc_allocator.cc:1083] InUse at 7fad2d829e00 of size 2304 next 24270



Also [fix] Missing Bucketize class in DE keras horovod demo.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [x] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?
Run a big model with a big batch size when using HKV.