### PR TITLE
[Fix] add HkvHashTableExportWithScores op

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/ops/hkv_hashtable_ops.cc
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/ops/hkv_hashtable_ops.cc
@@ -256,6 +256,26 @@ REGISTER_OP(PREFIX_OP_NAME(HkvHashTableSaveToFileSystem))
     .Attr("dirpath_env: string")
     .Attr("append_to_file: bool")
     .Attr("buffer_size: int >= 1");
+REGISTER_OP(PREFIX_OP_NAME(HkvHashTableExportWithScores))
+    .Input("table_handle: resource")
+    .Output("keys: key_dtype")
+    .Output("values: value_dtype")
+    .Output("scores: int64")
+    .Attr("key_dtype: type")
+    .Attr("value_dtype: type")
+    .Attr("split_size: int")
+    .SetShapeFn([](InferenceContext* c) {
+      ShapeHandle handle;
+      TF_RETURN_IF_ERROR(c->WithRank(c->input(0), 0, &handle));
+      ShapeHandle keys = c->UnknownShapeOfRank(1);
+      ShapeHandle values = c->UnknownShapeOfRank(1);
+      ShapeHandle scores = c->UnknownShapeOfRank(1);
+      ShapeAndType value_shape_and_type;
+      c->set_output(0, keys);
+      c->set_output(1, values);
+      c->set_output(2, scores);
+      return TFOkStatus;
+    });
 REGISTER_OP(PREFIX_OP_NAME(HkvHashTableExportKeysAndScores))
     .Input("table_handle: resource")
     .Output("keys: key_dtype")

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_creator.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_creator.py
@@ -395,7 +395,7 @@ class FileSystemSaverConfig(object):
                proc_size: int = None,
                proc_rank: int = None,
                save_path: str = None,
-               buffer_size: int = 4194304):
+               buffer_size: int = 4096):
     """ FileSystemSaverConfig can be used to assign save_path of DynamicEmbeddings.
     """
     if type(proc_rank) != type(proc_size):
@@ -493,7 +493,7 @@ class FileSystemSaver(DynamicEmbeddingSaver):
                proc_size: int = None,
                proc_rank: int = None,
                save_path: str = None,
-               buffer_size: int = 4194304):
+               buffer_size: int = 4096):
     self.config = FileSystemSaverConfig(proc_size=proc_size,
                                         proc_rank=proc_rank,
                                         save_path=save_path,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/hkv_hashtable_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/hkv_hashtable_ops.py
@@ -433,6 +433,20 @@ class HkvHashTable(LookupInterface):
             split_size=split_size)
     return keys, scores
 
+  def export_with_scores(self, split_size, name=None):
+    if not (split_size > 0 and isinstance(split_size, int)):
+      raise ValueError(f'split_size must be positive integer.')
+
+    with ops.name_scope(name, "%s_lookup_table_export_with_scores" % self.name,
+                        [self.resource_handle]):
+      with ops.colocate_with(self.resource_handle):
+        keys, values, scores = hkv_ops.tfra_hkv_hash_table_export_with_scores(
+            self.resource_handle,
+            key_dtype=self._key_dtype,
+            value_dtype=self._value_dtype,
+            split_size=split_size)
+    return keys, values, scores
+
   def save_to_file_system(self,
                           dirpath,
                           file_name=None,


### PR DESCRIPTION
# Description
Fix missing HkvHashTableExportWithScores op 
with help/collaborate from @MoFHeka and zhiheng

Fix the incompatiblity with new tf.keras.optimizers.Adagrad, it pass 0 shape tensor during the init, and we fix it by init with 0
Reduce the default buffer_size of FileSystemSaver to 4k


Brief Description of the PR:

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
