### PR TITLE
[FIX]add scope_name_prefix option to control size of file name 

### DIFF
--- a/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
+++ b/demo/dynamic_embedding/movielens-1m-keras-with-horovod/movielens-1m-keras-with-horovod.py
@@ -267,7 +267,9 @@ class ChannelEmbeddingLayers(tf.keras.layers.Layer):
         name=name + '_DenseUnifiedEmbeddingLayer',
         bp_v2=True,
         init_capacity=init_capacity,
-        kv_creator=kv_creator_dense)
+        kv_creator=kv_creator_dense,
+        short_file_name=True,
+    )
 
     kv_creator_sparse = get_kv_creator(mpi_size, mpi_rank, init_capacity,
                                        tf.dtypes.float32.size,
@@ -280,7 +282,9 @@ class ChannelEmbeddingLayers(tf.keras.layers.Layer):
         initializer=embedding_initializer,
         name=name + '_SparseUnifiedEmbeddingLayer',
         init_capacity=4096000,
-        kv_creator=kv_creator_sparse)
+        kv_creator=kv_creator_sparse,
+        short_file_name=True,
+    )
 
     self.dnn = tf.keras.layers.Dense(
         128,

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
@@ -128,6 +128,7 @@ class Embedding(tf.keras.layers.Layer):
                devices=None,
                name='DynamicEmbeddingLayer',
                with_unique=True,
+               short_file_name=False,
                **kwargs):
     """
     Creates an Embedding layer.
@@ -165,6 +166,8 @@ class Embedding(tf.keras.layers.Layer):
         distribute_strategy: Used when creating ShadowVariable.
         keep_distribution: Bool. If true, save and restore python object with
           devices information. Default is false.
+        short_file_name: Bool. If True, the file name will not use scope name as prefix and create_slots will not
+          use op_name to avoid file name over 255. the default is False to keep the same behavior as before.
     """
 
     try:
@@ -200,7 +203,8 @@ class Embedding(tf.keras.layers.Layer):
                                     kv_creator=kwargs.get('kv_creator', None),
                                     restrict_policy=kwargs.get(
                                         'restrict_policy', None),
-                                    bp_v2=kwargs.get('bp_v2', False))
+                                    bp_v2=kwargs.get('bp_v2', False),
+                                    short_file_name=short_file_name)
 
       self.distribute_strategy = kwargs.get('distribute_strategy', None)
       shadow_name = name + '-shadow' if name else 'ShadowVariable'

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/models.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/models.py
@@ -134,7 +134,7 @@ def _de_keras_save_func(original_save_func,
     _check_saveable_and_redirect_new_de_dir(hvd.rank())
     if hvd.rank() == 0:
       call_original_save_func()
-    _traverse_emb_layers_and_save(hvd.size, hvd.rank())
+    _traverse_emb_layers_and_save(hvd.size(), hvd.rank())
     hvd.join()  # Sync for avoiding rank conflict
 
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -867,7 +867,11 @@ def create_slots(variable, init, slot_name, op_name, bp_v2):
     params_var_ = primary.params
 
   scope_store = variable_scope._get_default_variable_store()
-  full_name = params_var_.name + "/" + op_name + "/" + slot_name
+  if params_var_.short_file_name:
+    full_name = params_var_.name + "/" + slot_name
+  else:
+    full_name = params_var_.name + "/" + op_name + "/" + slot_name
+
   if full_name not in scope_store._vars:
     with ops.colocate_with(primary, ignore_existing=True):
       slot_variable_ = de.Variable(


### PR DESCRIPTION
1. [FIX] add scope_name_prefix option to control size of file name to reduce the liklyhood of file name > 255 chars
2. FIX pass in fun obj bug for file name.

# Description

Brief Description of the PR:

Fixes # (issue)

## Type of change

- [ ] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [ ] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [ ] By running yapf
    - [ ] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

If you're adding a bugfix or new feature please describe the tests that you ran to verify your changes:
*  
