### PR TITLE
[Fix] Some compatibility patches for Tensorflow versions and runtime environments

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -541,11 +541,14 @@ class Variable(EmbeddingWeights, base.Trackable):
     self.short_file_name = short_file_name
 
     def _get_default_devices():
-      gpu_list = [
-          x.name
-          for x in device_lib.list_local_devices()
-          if x.device_type == "GPU"
-      ]
+      try:
+        gpu_list = [
+            x.name
+            for x in device_lib.list_local_devices()
+            if x.device_type == "GPU"
+        ]
+      except:
+        gpu_list = []
       return gpu_list[0:1] or [
           "/CPU:0",
       ]


### PR DESCRIPTION
# Description

[fix] There is no signature "strict_predicate_restore" in register_checkpoint_saver fucntion from tf saved_model registration when TF version 2.9. Make a function signature inspect to be compitible.

[fix] device_lib.list_local_devices() may run fail in some case, then use CPU as default device.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Run any FileSystem Saver in TF version 2.9.3
