### PR TITLE
[Fix] Change all "try" version compatibility codes to version detection and remove some libraries.

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/BUILD
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/BUILD
@@ -58,35 +58,63 @@ custom_op_library(
     ],
 )
 
+# _math_ops.so has been removed since TF2 performance is good enough.
+config_setting(
+    name = "build_math_op",
+    values = {
+        "define": "BUILD_MATH_OP=1",
+    },
+)
+
 custom_op_library(
     name = "_math_ops.so",
-    srcs = [
-        "kernels/segment_reduction_ops.h",
-        "kernels/segment_reduction_ops_impl.cc",
-        "kernels/segment_reduction_ops_impl.h",
-        "ops/math_ops.cc",
-        "utils/utils.h",
-    ],
-    cuda_srcs = [
-        "kernels/segment_reduction_ops.h",
-        "kernels/segment_reduction_ops_gpu.cu.cc",
-    ],
+    srcs = select({
+        ":build_math_op": [
+            "kernels/segment_reduction_ops.h",
+            "kernels/segment_reduction_ops_impl.cc",
+            "kernels/segment_reduction_ops_impl.h",
+            "ops/math_ops.cc",
+            "utils/utils.h",
+        ],
+        "//conditions:default": [],
+    }),
+    cuda_srcs = select({
+        ":build_math_op": [
+            "kernels/segment_reduction_ops.h",
+            "kernels/segment_reduction_ops_gpu.cu.cc",
+        ],
+        "//conditions:default": [],
+    }),
+)
+
+# _data_flow_ops.so has been removed since TF2.9 already support int32/int64 GPU op.
+config_setting(
+    name = "build_data_flow_op",
+    values = {
+        "define": "BUILD_DATA_FLOW_OP=1",
+    },
 )
 
 custom_op_library(
     name = "_data_flow_ops.so",
-    srcs = [
-        "kernels/dynamic_partition_op.cc",
-        "kernels/dynamic_stitch_op.cc",
-        "ops/data_flow_ops.cc",
-        "utils/utils.h",
-    ],
-    cuda_srcs = [
-        "kernels/fill_functor.cu.cc",
-        "kernels/dynamic_partition_op_gpu.cu.cc",
-        "kernels/dynamic_stitch_op_gpu.cu.cc",
-        "utils/utils.h",
-    ],
+    srcs = select({
+        ":build_data_flow_op": [
+            "kernels/dynamic_partition_op.cc",
+            "kernels/dynamic_stitch_op.cc",
+            "ops/data_flow_ops.cc",
+            "utils/utils.h",
+        ],
+        "//conditions:default": [],
+    }),
+    cuda_srcs = select({
+        ":build_data_flow_op": [
+            "kernels/fill_functor.cu.cc",
+            "kernels/dynamic_partition_op_gpu.cu.cc",
+            "kernels/dynamic_stitch_op_gpu.cu.cc",
+            "utils/utils.h",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 # TODO: Add hkv targets.

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/keras/layers/embedding.py
@@ -18,6 +18,8 @@ Dynamic Embedding is designed for Large-scale Sparse Weights Training.
 See [Sparse Domain Isolation](https://github.com/tensorflow/community/pull/237)
 """
 
+from packaging import version
+
 import tensorflow as tf
 
 from tensorflow.python.eager import context
@@ -28,31 +30,35 @@ from tensorflow.python.keras.utils import tf_utils
 
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import HvdVariable
 
-try:  # tf version >= 2.14.0
+if version.parse(tf.__version__) >= version.parse("2.14"):
   from tensorflow.python.distribute import distribute_lib as distribute_ctx
-
-  assert hasattr(distribute_ctx, 'has_strategy')
-except:
+else:
   from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
 from tensorflow.python.distribute import values_util
 from tensorflow.python.framework import ops
 from tensorflow.python.ops.variables import VariableAggregation
 from tensorflow.python.platform import tf_logging
 
-try:  # The data_structures has been moved to the new package in tf 2.11
+if version.parse(tf.__version__) >= version.parse("2.11"):
+  # The data_structures has been moved to the new package in tf 2.11
   from tensorflow.python.trackable import data_structures
-except:
+else:
   from tensorflow.python.training.tracking import data_structures
 
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import \
   TrainableWrapperDistributedPolicy
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_save_restore_patch import de_fs_saveable_class_names
 
-try:  # tf version >= 2.16
-  from tf_keras.layers import Layer
-  from tf_keras.initializers import RandomNormal, Zeros, serialize
-  from tf_keras import constraints
-except:
+if version.parse(tf.__version__) >= version.parse("2.16"):
+  try:  # independently import tf_keras
+    from tf_keras.layers import Layer
+    from tf_keras.initializers import RandomNormal, Zeros, serialize
+    from tf_keras import constraints
+  except:
+    from tensorflow.python.keras.legacy_tf_layers.base import Layer
+    from tensorflow.python.keras.initializers import RandomNormal, Zeros, serialize
+    from tensorflow.python.keras import constraints
+else:
   from tensorflow.keras.layers import Layer
   from tensorflow.keras.initializers import RandomNormal, Zeros, serialize
   from tensorflow.keras import constraints

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_variable_test.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/kernel_tests/dynamic_embedding_variable_test.py
@@ -23,12 +23,14 @@ import itertools
 import math
 import numpy as np
 import os
+from packaging import version
 import six
 import tempfile
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
 from tensorflow_recommenders_addons.utils.check_platform import is_macos, is_arm64
 
+from tensorflow import version as tf_version
 from tensorflow.core.protobuf import config_pb2
 from tensorflow.python.client import session
 from tensorflow.python.eager import context
@@ -56,22 +58,26 @@ from tensorflow.python.training import adam
 from tensorflow.python.training import saver
 from tensorflow.python.training import server_lib
 from tensorflow.python.training import training
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.checkpoint.checkpoint import Checkpoint
-except:
+else:
   from tensorflow.python.training.tracking.util import Checkpoint
 from tensorflow.python.util import compat
 
-try:  # tf version <= 2.15
+if version.parse(tf_version.VERSION) >= version.parse("2.16"):
+  try:  # independently import tf_keras
+    from tf_keras import layers
+  except:
+    from tensorflow.python.keras import layers
+else:
   from tensorflow_estimator.python.estimator import estimator
   from tensorflow_estimator.python.estimator import estimator_lib
   from tensorflow.keras import layers
-except:
-  from tf_keras import layers
 
-try:  # The data_structures has been moved to the new package in tf 2.11
+if version.parse(tf_version.VERSION) >= version.parse("2.11"):
+  # The data_structures has been moved to the new package in tf 2.11
   from tensorflow.python.trackable import data_structures
-except:
+else:
   from tensorflow.python.training.tracking import data_structures
 
 try:

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_ops.py
@@ -18,10 +18,13 @@ Dynamic Embedding is designed for Large-scale Sparse Weights Training.
 See [Sparse Domain Isolation](https://github.com/tensorflow/community/pull/237)
 """
 
+from packaging import version
+
 from tensorflow_recommenders_addons import dynamic_embedding as de
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.shadow_embedding_ops import DEResourceVariable
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights
 
+from tensorflow import version as tf_version
 from tensorflow.python.eager import tape as tape_record
 if not hasattr(tape_record, 'record_operation'):
   # tf version >= 2.13.0
@@ -30,31 +33,31 @@ from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
 from tensorflow.python.framework import sparse_tensor
 from tensorflow.python.framework import tensor_shape
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.framework.tensor import Tensor
-except:
+else:
   from tensorflow.python.framework.ops import Tensor
 from tensorflow.python.ops import array_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import sparse_ops
 from tensorflow.python.ops import variable_scope
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.ops.array_ops_stack import stack
-except:
+else:
   from tensorflow.python.ops.array_ops import stack
-try:  # tf version >= 2.10.0
+if version.parse(tf_version.VERSION) >= version.parse("2.10"):
   from tensorflow.python.trackable import base as trackable
-except:
+else:
   from tensorflow.python.training.tracking import base as trackable
-try:  # The data_structures has been moved to the new package in tf 2.11
+if version.parse(tf_version.VERSION) >= version.parse("2.11"):
+  # The data_structures has been moved to the new package in tf 2.11
   from tensorflow.python.trackable import data_structures
-except:
+else:
   from tensorflow.python.training.tracking import data_structures
 
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.distribute import distribute_lib as distribute_ctx
-  assert hasattr(distribute_ctx, 'has_strategy')
-except:
+else:
   from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
 
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_optimizer.py
@@ -16,28 +16,29 @@
 """patch on optimizers"""
 
 import functools
+from packaging import version
 import six
 
 from tensorflow_recommenders_addons import dynamic_embedding as de
 
+from tensorflow import version as tf_version
 from tensorflow.python.distribute import central_storage_strategy
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.distribute import distribute_lib as distribute_ctx
-  assert hasattr(distribute_ctx, 'has_strategy')
-except:
+else:
   from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
 from tensorflow.python.distribute import parameter_server_strategy
 from tensorflow.python.distribute import parameter_server_strategy_v2
 from tensorflow.python.eager import context
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.framework.tensor import Tensor
-except:
+else:
   from tensorflow.python.framework.ops import Tensor
-try:  # tf version >= 2.13.0
+if version.parse(tf_version.VERSION) >= version.parse("2.13"):
   from tensorflow.python.framework.indexed_slices import IndexedSlices
-except:
+else:
   from tensorflow.python.framework.ops import IndexedSlices
 from tensorflow.python.keras import backend
 from tensorflow.python.keras import initializers
@@ -46,9 +47,9 @@ from tensorflow.python.ops import control_flow_ops
 from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import variables
 from tensorflow.python.ops import variable_scope
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.ops.cond import cond
-except:
+else:
   from tensorflow.python.ops.control_flow_ops import cond
 from tensorflow.python.platform import tf_logging as logging
 from tensorflow.python.training import optimizer
@@ -57,31 +58,35 @@ try:
   from tensorflow.python.distribute.sharded_variable import ShardedVariable
 except:
   ShardedVariable = type('Dummy', (object,), {})
-try:  # tf version >= 2.10.0
+if version.parse(tf_version.VERSION) >= version.parse("2.10"):
   from tensorflow.python.trackable import base as trackable
-except:
+else:
   from tensorflow.python.training.tracking import base as trackable
 from tensorflow.python.keras.optimizer_v2 import optimizer_v2 as optimizer_v2_legacy
 from tensorflow.python.keras.optimizer_v2 import utils as optimizer_v2_legacy_utils
 
-try:  # tf version >= 2.16
-  from tf_keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
-  from tf_keras.optimizers import Optimizer as keras_OptimizerV2
-except:
-  try:  # Keras version >= 2.12.0
-    from tensorflow.keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
-    from tensorflow.keras.optimizers import Optimizer as keras_OptimizerV2
+if version.parse(tf_version.VERSION) >= version.parse("2.16"):
+  try:  # independently import tf_keras
+    from tf_keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
+    from tf_keras.optimizers import Optimizer as keras_OptimizerV2
   except:
-    from tensorflow.keras.optimizers import Optimizer as keras_OptimizerV2_legacy
-    keras_OptimizerV2 = keras_OptimizerV2_legacy
+    from tensorflow.python.keras.optimizers import Optimizer as keras_OptimizerV2_legacy
+    from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as keras_OptimizerV2
+elif version.parse(tf_version.VERSION) >= version.parse("2.12"):
+  from tensorflow.keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
+  from tensorflow.keras.optimizers import Optimizer as keras_OptimizerV2
+else:
+  from tensorflow.keras.optimizers import Optimizer as keras_OptimizerV2_legacy
+  keras_OptimizerV2 = keras_OptimizerV2_legacy
 
 from tensorflow.python.eager import tape
 from tensorflow.python.distribute import values_util as distribute_values_util
 from tensorflow.python.distribute import distribute_utils
 from tensorflow.python.ops.variables import VariableAggregation
-try:  # The data_structures has been moved to the new package in tf 2.11
+if version.parse(tf_version.VERSION) >= version.parse("2.11"):
+  # The data_structures has been moved to the new package in tf 2.11
   from tensorflow.python.trackable import data_structures
-except:
+else:
   from tensorflow.python.training.tracking import data_structures
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.dynamic_embedding_variable import \
   TrainableWrapperDistributedPolicy

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/dynamic_embedding_variable.py
@@ -19,6 +19,7 @@ See [Sparse Domain Isolation](https://github.com/tensorflow/community/pull/237)
 """
 
 import functools
+from packaging import version
 import re
 import typing
 import tensorflow as tf
@@ -27,10 +28,9 @@ from tensorflow_recommenders_addons import dynamic_embedding as de
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights
 from tensorflow_recommenders_addons.utils.check_platform import is_macos, is_arm64
 
-try:  # tf version >= 2.14.0
+if version.parse(tf.__version__) >= version.parse("2.14"):
   from tensorflow.python.distribute import distribute_lib as distribute_ctx
-  assert hasattr(distribute_ctx, 'has_strategy')
-except:
+else:
   from tensorflow.python.distribute import distribution_strategy_context as distribute_ctx
 from tensorflow.python.distribute import distribute_utils
 from tensorflow.python.distribute import values as distribute_values_lib
@@ -58,16 +58,21 @@ from tensorflow.python.framework import ops
 
 from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2
 
-try:  # tf version >= 2.16
-  from tf_keras.initializers import Initializer
-  from tf_keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
-  from tf_keras.optimizers import Optimizer as keras_OptimizerV2
-except:
+if version.parse(tf.__version__) >= version.parse("2.16"):
+  try:  # independently import tf_keras
+    from tf_keras.initializers import Initializer
+    from tf_keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
+    from tf_keras.optimizers import Optimizer as keras_OptimizerV2
+  except:
+    from tensorflow.python.keras.initializers.initializers_v2 import Initializer
+    from tensorflow.python.keras.optimizers import Optimizer as keras_OptimizerV2_legacy
+    from tensorflow.python.keras.optimizer_v2.optimizer_v2 import OptimizerV2 as keras_OptimizerV2
+else:
   from tensorflow.keras.initializers import Initializer
-  try:  # Keras version >= 2.12.0
+  if version.parse(tf.__version__) >= version.parse("2.12"):
     from tensorflow.keras.optimizers.legacy import Optimizer as keras_OptimizerV2_legacy
     from tensorflow.keras.optimizers import Optimizer as keras_OptimizerV2
-  except:
+  else:
     from tensorflow.keras.optimizers import Optimizer as keras_OptimizerV2_legacy
     keras_OptimizerV2 = keras_OptimizerV2_legacy
 
@@ -84,35 +89,36 @@ from tensorflow.python.ops import math_ops
 from tensorflow.python.ops import parsing_ops
 from tensorflow.python.ops import string_ops
 from tensorflow.python.ops import variable_scope
-try:  # tf version >= 2.14.0
+if version.parse(tf.__version__) >= version.parse("2.14"):
   from tensorflow.python.ops.control_flow_assert import Assert
-except:
+else:
   from tensorflow.python.ops.control_flow_ops import Assert
-try:  # tf version >= 2.14.0
+if version.parse(tf.__version__) >= version.parse("2.14"):
   from tensorflow.python.ops.cond import cond
-except:
+else:
   from tensorflow.python.ops.control_flow_ops import cond
-try:  # tf version >= 2.14.0
+if version.parse(tf.__version__) >= version.parse("2.14"):
   from tensorflow.python.ops.while_loop import while_loop
-except:
+else:
   from tensorflow.python.ops.control_flow_ops import while_loop
 from tensorflow.python.platform import tf_logging
 from tensorflow.python.training.optimizer import Optimizer
-try:  # tf version >= 2.10.0
+if version.parse(tf.__version__) >= version.parse("2.10"):
   from tensorflow.python.trackable import base
-except:
+else:
   from tensorflow.python.training.tracking import base
-try:  # tf version >= 2.10.0
+if version.parse(tf.__version__) >= version.parse("2.10"):
   from tensorflow.python.training.saving.saveable_object_util import _PythonStringStateSaveable as TF_PythonStringStateSaveable
-except:
+else:
   from tensorflow.python.training.tracking.base import PythonStringStateSaveable as TF_PythonStringStateSaveable
-try:  # The data_structures has been moved to the new package in tf 2.11
+if version.parse(tf.__version__) >= version.parse("2.11"):
+  # The data_structures has been moved to the new package in tf 2.11
   from tensorflow.python.trackable import data_structures
-except:
+else:
   from tensorflow.python.training.tracking import data_structures
-try:  # tf version >= 2.14.0
+if version.parse(tf.__version__) >= version.parse("2.14"):
   from tensorflow.python.trackable import python_state
-except:
+else:
   from tensorflow.python.training.tracking import python_state
 from tensorflow.python.util.tf_export import tf_export
 

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/shadow_embedding_ops.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/shadow_embedding_ops.py
@@ -33,6 +33,8 @@ The `shadow_ops` submodule is designed to support usage on `tf.function`
 and modular style development, like keras.
 """
 
+from packaging import version
+
 import tensorflow as tf
 
 from tensorflow.python.distribute import distribute_lib
@@ -48,9 +50,9 @@ from tensorflow_recommenders_addons import dynamic_embedding as de
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.embedding_weights import EmbeddingWeights, \
   TrainableWrapper
 
-try:  # tf version >= 2.10.0
+if version.parse(tf.__version__) >= version.parse("2.10"):
   from tensorflow.python.trackable import base as trackable
-except:
+else:
   from tensorflow.python.training.tracking import base as trackable
 
 from tensorflow.python.distribute import distribute_utils

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/ops/tf_patch.py
@@ -14,6 +14,9 @@
 
 # lint-as: python3
 """patch on tensorflow"""
+
+from packaging import version
+
 from tensorflow_recommenders_addons import dynamic_embedding as de
 
 try:
@@ -39,18 +42,19 @@ except ImportError:
   kinit_K = None
   pass  # for compatible with standalone Keras
 
+from tensorflow import version as tf_version
 from tensorflow.core.framework import node_def_pb2
 from tensorflow.python.eager import context
 from tensorflow.python.framework import device as pydev
 from tensorflow.python.framework import dtypes
 from tensorflow.python.framework import ops
-try:  # tf version >= 2.14.0
+if version.parse(tf_version.VERSION) >= version.parse("2.14"):
   from tensorflow.python.framework.tensor import Tensor
-except:
+else:
   from tensorflow.python.framework.ops import Tensor
-try:  # tf version >= 2.13.0
+if version.parse(tf_version.VERSION) >= version.parse("2.13"):
   from tensorflow.python.framework.indexed_slices import IndexedSlices
-except:
+else:
   from tensorflow.python.framework.ops import IndexedSlices
 from tensorflow.python.keras import initializers as kinit1
 from tensorflow.python.ops import control_flow_ops
@@ -63,9 +67,9 @@ from tensorflow.python.platform import tf_logging
 from tensorflow.python.training import device_setter
 from tensorflow.python.training import optimizer
 from tensorflow.python.training import slot_creator
-try:  # tf version >= 2.10.0
+if version.parse(tf_version.VERSION) >= version.parse("2.10"):
   from tensorflow.python.checkpoint import restore as ckpt_base
-except:
+else:
   from tensorflow.python.training.tracking import base as ckpt_base
 
 _PARTITION_SHAPE = 'partition_shape'

--- a/tensorflow_recommenders_addons/dynamic_embedding/python/train/checkpoint.py
+++ b/tensorflow_recommenders_addons/dynamic_embedding/python/train/checkpoint.py
@@ -15,16 +15,19 @@
 # lint-as: python3
 
 import os.path
+from packaging import version
+
 from tensorflow_recommenders_addons.dynamic_embedding.python.ops.tf_save_restore_patch import de_fs_saveable_class_names, de_fs_sub_saveable_class_names
 from tensorflow_recommenders_addons import dynamic_embedding as de
 
+from tensorflow import version as tf_version
 from tensorflow.python.eager import context
 from tensorflow.python.framework import constant_op
 from tensorflow.python.framework import ops
-try:  # tf version >= 2.10.0
+if version.parse(tf_version.VERSION) >= version.parse("2.10"):
   from tensorflow.python.checkpoint.checkpoint import Checkpoint as TFCheckpoint
   from tensorflow.python.checkpoint import restore as ckpt_base
-except:
+else:
   from tensorflow.python.training.tracking.util import Checkpoint as TFCheckpoint
   from tensorflow.python.training.tracking import base as ckpt_base
 from tensorflow.python.lib.io import file_io


### PR DESCRIPTION
# Description

Sometimes the APIs exist, but they are buggy and should not be referenced.
This makes it more precise to avoid introducing buggy libraries.

Also removes unnecessary operator libraries(math_ops,data_flow_ops) compilation and supports compilation under TF2.18.


## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Run any code use DE Embedding layer in keras eager mode.
