### PR TITLE
[Fix] Redis cluster to exceed the maximum number of connections

### DIFF
--- a/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
+++ b/tensorflow_recommenders_addons/dynamic_embedding/core/kernels/redis_impl/redis_cluster_connection_pool.hpp
@@ -22,6 +22,7 @@ limitations under the License.
 
 #include <chrono>
 #include <iostream>
+#include <random>
 
 #include "redis_connection_util.hpp"
 #include "thread_pool.h"
@@ -213,6 +214,12 @@ class RedisWrapper<RedisInstance, K, V,
     return nullptr;
   }
 
+  int GenerateRedisRandomTag() {
+    static thread_local std::mt19937 generator(std::random_device{}());
+    std::uniform_int_distribution<int> distribution(0, 16383);
+    return distribution(generator);
+  }
+
  public:
   virtual std::vector<std::string> GetKeyBucketsAndOptimizerParamsWithName(
       const std::string &keys_prefix_name,
@@ -224,7 +231,7 @@ class RedisWrapper<RedisInstance, K, V,
                   ::sw::redis::StringView hkey) {
       connection.send("CLUSTER SLOTS");
     };
-    ::sw::redis::StringView _hkey("0");
+    ::sw::redis::StringView _hkey(std::to_string(GenerateRedisRandomTag()));
     std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter> reply;
     try {
       reply = redis_conn_read->command(cmd, _hkey);
@@ -363,7 +370,7 @@ class RedisWrapper<RedisInstance, K, V,
                   ::sw::redis::StringView hkey) {
       connection.send("CLUSTER NODES");
     };
-    ::sw::redis::StringView _hkey("0");
+    ::sw::redis::StringView _hkey(std::to_string(GenerateRedisRandomTag()));
     std::unique_ptr<redisReply, ::sw::redis::ReplyDeleter> reply;
     try {
       reply = redis_conn_read->command(cmd, _hkey);


### PR DESCRIPTION
# Description

When there are a large number of client NODES, the initialization commands CLUSTER SLOTS 0 and CLUSTER NODES 0 cause shard 0 in the Redis cluster to exceed the maximum number of connections.

## Type of change

- [x] Bug fix
- [ ] New Tutorial
- [ ] Updated or additional documentation
- [ ] Additional Testing
- [ ] New Feature

# Checklist:

- [x] I've properly [formatted my code according to the guidelines](https://github.com/tensorflow/recommenders-addons/blob/master/CONTRIBUTING.md#coding-style)
    - [x] By running yapf
    - [x] By running clang-format
- [ ] This PR addresses an already submitted issue for TensorFlow Recommenders-Addons
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Create a model running with hundreds of Redis tables and distributed in hundreds of nodes sharing same Redis cluster.
